### PR TITLE
Resolve Issue #25: CLAUDE.md docs &amp; consolidate design docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# Mathematador — Technical Guide for Agents
+
+Mathematador is a math-practice mobile game ("El Coliseo de los Números" / *The Numbers Coliseum*) built as a two-workspace **npm workspaces monorepo**:
+
+- **`mathematador-app/`** — React Native + Expo (SDK 56) client, targets iOS/Android/Web.
+- **`server/`** — Express + Knex + PostgreSQL backend.
+
+The gameplay theme: the player is a rookie *Torero* solving arithmetic "passes" (addition/subtraction/multiplication/division) with a friendly companion, the **Toro Numérico** (never an enemy — see `agents/instructions.md` §2 for the strict 0+ theming rules before touching any Toro-related UI). Full game design lives in [`docs/game_proposal.md`](docs/game_proposal.md) and [`docs/game_structure.md`](docs/game_structure.md) — read those for *what the game is*; this file is about *how the code is organized and what to watch out for*.
+
+For workspace-specific detail, see the nested guides: [`mathematador-app/CLAUDE.md`](mathematador-app/CLAUDE.md) and [`server/CLAUDE.md`](server/CLAUDE.md).
+
+## Architecture at a glance
+
+```
+mathematador-app (Redux + redux-persist/AsyncStorage, offline-first)
+    │  Orval-generated client (src/_generated/api.ts), axios
+    ▼
+server (Express, requireAuth middleware, restAPICall wrapper)
+    │  Knex
+    ▼
+PostgreSQL
+```
+
+A single OpenAPI spec, `analytics/_swaggers/be_fe.yaml`, drives **all** generated code on both sides via `orval.config.ts` (run with `npm run generate`). Never hand-edit anything under `_generated/` — edit the spec and regenerate. CI (`.github/workflows/pr-checks.yml`) fails the build if `npm run generate` produces a diff, i.e. the generated code and the spec must always be in sync in every commit.
+
+## Dev commands (run from repo root)
+
+```bash
+npm run dev          # concurrently runs server (nodemon) + Expo app, via scripts/dev.js
+npm run lint          # eslint . across both workspaces
+npm test              # server tests, then app tests
+npm run build          # server tsc build, then app `expo export -p web`
+npm run generate       # regenerate all Orval clients/models/zod schemas from the OpenAPI spec
+```
+
+Ports and DB connection come from `.env` (see `.env.example`) — `PORT`/`EXPO_PORT` default to 4076/4075, `DATABASE=stage|production` switches which Postgres connection string `server/src/knexWrapper.ts` uses (not `NODE_ENV`).
+
+## Coding conventions (enforced by `eslint.config.js`, not just style advice)
+
+- **No relative imports.** Only `@/...` path aliases (`@/*` maps to each workspace's `src/*` and `./*`). This is a hard ESLint error (`no-restricted-imports`).
+- **No default-exported function/class declarations.** Always `const Foo = () => {...}; export default Foo;`.
+- **Arrow functions only** (`func-style: expression`) — no `function` declarations.
+- **Explicit return types required** on every function.
+- `max-lines: 150` per file (configs/ dir is exempted), `complexity: 10`, `max-depth: 4`, `max-params: 4`.
+- **`id-length: min 4`** — no single/double-letter variable names except a short allow-list (`id`, `row`, `x`, `y`, `min`, `max`, etc.). Use `firstNumber`/`secondNumber`, not `a`/`b`.
+- No `console.log` in app code (`no-console`, except `server/src/migrations/**`).
+- `unknown` and `as` type assertions are banned; `any` is a lint error too.
+- Prettier runs as an ESLint rule (`prettier/prettier`) — `npx eslint --fix` resolves most formatting nits.
+
+Run `npx eslint <path>` on files you touch before considering a change done — `npm run lint` at the repo root is what CI actually runs.
+
+## Git / PR workflow
+
+Full policy is in [`agents/instructions.md`](agents/instructions.md) — summary:
+
+1. Branch from `develop`: `issue-<number>-<short-description>`.
+2. Implement, then verify locally (see below) — CI checks (`pr-checks.yml`) sometimes don't report on a PR promptly, so **run the equivalent commands locally before merging, don't rely on the PR's check status alone**: `npm run generate && git diff --exit-code`, `npm run lint`, `npm run build --workspace=server`, `npm run build --workspace=mathematador-app`, `npm test`.
+3. Push directly — pushes to feature branches (`issue-*`) are pre-approved per `agents/instructions.md` §3.4. Pushes/merges to `develop`/`main` are not.
+4. Open a PR targeting `develop` with `Closes #<number>` in the body.
+5. This repo's convention has been **squash-merge**, with the feature branch deleted (locally and on origin) immediately after.
+6. `agents/verify.js` / `agents/submit-pr.js` / `agents/issue-helper.js` automate steps 2/4 and branch setup respectively, if you'd rather run a script than the raw commands.
+
+An automated review bot (`cubic-dev-ai`) comments on PRs — treat its findings as a real second opinion, verify each one against the code before dismissing or fixing.
+
+## Known gotchas & pre-existing bugs
+
+These were found while mapping the codebase (2026-08-27) and are **not** things you introduced — don't waste time re-discovering them, but do fix them if you're touching the affected area (or check the standing follow-up task chips in this session for three of them already queued up).
+
+### 🔴 Gauntlet & Daily Challenge are completely broken (minigame-id mismatch)
+
+`mathematador-app/src/configs/minigames.ts` registers its only minigame as `id: "SingleLineMinigame"`. Every other part of the system — the generated `Minigame` enum, the server, `server/src/utils/mathGenerator.ts`, and critically `mathematador-app/src/screens/GauntletScreen.tsx` (both its server-backed path and its offline fallback) — uses the string `"singleLine"`. `ChallengeGameScreen.tsx:241` looks up the component by exact string match, so **starting a Gauntlet run or the Daily Challenge always renders "Minigame component not found."** instead of the game. The normal per-operation practice flow is unaffected because it sources the id from the same config it looks it up in (`helpers/getChalengeByLevel.ts`). Fix: align on `"singleLine"` everywhere (that's what the DB/enum/server already use).
+
+### 🔴 Subtraction and division give wrong answers in the main practice flow
+
+`mathematador-app/src/configs/operations.ts`: subtraction's `getResult` reduces with `+` (copy-pasted from addition); division's reduces with `*` (copy-pasted from multiplication). This is usually masked because most exercises carry a server-computed `.result` field, but the **main "Operation Select → Challenge Select → Start" loop** generates exercises via `helpers/getChalengeByLevel.ts`, which never sets `.result` — so for that flow, subtraction/division challenges compute the wrong expected answer and are effectively unplayable.
+
+### 🟠 Auth is not wired up end-to-end
+
+No `LoginScreen`/`RegisterScreen` exists — there is no UI path to obtain a JWT. Even if there were, `userSlice`'s `UserState` never stores the user's `id`, so `mathematador-app/src/utils/api-client.ts`'s `getPersistedViewerId()` always resolves to `undefined`, meaning a stored token would never be re-attached to requests anyway. Every screen that calls an authenticated endpoint (`GauntletScreen`, `TiendaScreen`) is written defensively with try/catch + local-Redux fallback specifically because of this — assume authenticated calls will 401 and silently fall back until this is fixed.
+
+### 🔴 Unauthenticated password-reset endpoint (security)
+
+`server/src/routes.ts` registers `PUT /user/login` (→ `userLoginPassword.ts`) **without** the `requireAuth` middleware every other sensitive route uses. The handler falls back to updating the *first row in the `users` table* (in practice the seeded root admin) when `request.userId` is unset — which it always is on this unauthenticated route. Anyone who knows the endpoint exists can reset the admin account's password. Needs a real fix (proper forgotten-password token flow, or at minimum `requireAuth` + scoping the update to the caller's own row) — see the standing follow-up task for this.
+
+### Dead / vestigial code worth knowing about (so you don't build on it by mistake)
+
+- `redux/slices/gameSlice.ts` — not read or dispatched by any live screen; real state lives in `userSlice.ts`.
+- `configs/challengeExercises.ts` (1568 lines, hardcoded exercise table) — superseded by `helpers/getChalengeByLevel.ts`; appears unused.
+- `types/enums.ts` (both `mathematador-app` and `server` copies) — unused leftover boilerplate from a different project template.
+- `mathematador-app/src/hooks/useTypedSelector.ts` — empty file.
+- `HeaderModule` (`components/common/HeaderEvents.ts`) — no such native module is registered anywhere; always a no-op.
+- `expo-jwt` dependency and `EXPO_PUBLIC_JWT_SECRET` env var — unused (JWT signing is server-only).
+- `server/src/_generated/serverAPI.ts` — type-extraction plumbing only, never called at runtime; real routing is 100% hand-written in `server/src/routes.ts`.
+- `server/src/migrations/20241109002335_gameData.js` — a no-op migration (empty `up`/`down`).
+- `GauntletScreen.tsx`'s leaderboard — fully hardcoded/fake, not backed by any API.
+- `QueryClientProvider` is set up in `app/_layout.tsx` but no screen uses the generated `use*` react-query hooks — all screens call the plain async fetchers directly.
+
+### Alert.alert is a no-op on the Expo web export
+
+React Native's `Alert.alert` (used for "Time's Up!" and the Toro Hint popup) doesn't render anything when the app is built/run as `expo export -p web` / `expo start --web`. Fine on native, silently does nothing on web — don't rely on it for critical web-reachable flows without a fallback.
+
+## Where to look next
+
+- Game design & mechanics: [`docs/game_proposal.md`](docs/game_proposal.md), [`docs/game_structure.md`](docs/game_structure.md).
+- Agent roles, theming rules, full git policy: [`agents/instructions.md`](agents/instructions.md).
+- Frontend specifics: [`mathematador-app/CLAUDE.md`](mathematador-app/CLAUDE.md).
+- Backend specifics: [`server/CLAUDE.md`](server/CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,16 @@ The gameplay theme: the player is a rookie *Torero* solving arithmetic "passes" 
 
 For workspace-specific detail, see the nested guides: [`mathematador-app/CLAUDE.md`](mathematador-app/CLAUDE.md) and [`server/CLAUDE.md`](server/CLAUDE.md).
 
+## Current direction: the MVP epic
+
+As of 2026-08-27, active work is driven by [issue #29](https://github.com/webstartapp/mathematador/issues/29) ("Epic: Mathematador MVP — mathematador.net") and its ~14 child issues — check it first for current priorities/status rather than assuming this file's architecture description is the target state. The MVP **deliberately reverses** some facts documented below:
+
+- **Offline-first → mandatory login for the web MVP.** The app today has no login UI at all and is designed to work fully offline (see `agents/instructions.md` §2). The MVP requires a real authenticated session to enter at all (#30) — offline/anonymous play is explicitly out for the web target, though this file's "offline-first" architecture description still describes today's actual code until that lands.
+- **No ads/consent/CMS/admin infra today** — the MVP adds all of it from scratch (consent gate #31, settings-with-history #32, CMS-backed `/info`/`/admin` pages #33–#36, ads #38). None of this exists yet in the codebase this file describes.
+- **Only one minigame exists today** (`SingleLineMinigame`) — the MVP's game-modes rework (#37) is blocked on agreeing a roster of ~10 (#28) before it can proceed.
+
+The rest of this file (and the nested workspace guides) describes the codebase **as it stands today**, which is still accurate for anything the MVP hasn't touched yet — just don't be surprised when auth, ads, or an admin panel show up; check the epic for what's landed.
+
 ## Architecture at a glance
 
 ```
@@ -64,23 +74,23 @@ An automated review bot (`cubic-dev-ai`) comments on PRs — treat its findings 
 
 ## Known gotchas & pre-existing bugs
 
-These were found while mapping the codebase (2026-08-27) and are **not** things you introduced — don't waste time re-discovering them, but do fix them if you're touching the affected area (or check the standing follow-up task chips in this session for three of them already queued up).
+These were found while mapping the codebase (2026-08-27) and are **not** things you introduced — don't waste time re-discovering them, but do fix them if you're touching the affected area. Several are already tracked as part of the [MVP epic](https://github.com/webstartapp/mathematador/issues/29)'s child issues, noted below.
 
 ### 🔴 Gauntlet & Daily Challenge are completely broken (minigame-id mismatch)
 
-`mathematador-app/src/configs/minigames.ts` registers its only minigame as `id: "SingleLineMinigame"`. Every other part of the system — the generated `Minigame` enum, the server, `server/src/utils/mathGenerator.ts`, and critically `mathematador-app/src/screens/GauntletScreen.tsx` (both its server-backed path and its offline fallback) — uses the string `"singleLine"`. `ChallengeGameScreen.tsx:241` looks up the component by exact string match, so **starting a Gauntlet run or the Daily Challenge always renders "Minigame component not found."** instead of the game. The normal per-operation practice flow is unaffected because it sources the id from the same config it looks it up in (`helpers/getChalengeByLevel.ts`). Fix: align on `"singleLine"` everywhere (that's what the DB/enum/server already use).
+`mathematador-app/src/configs/minigames.ts` registers its only minigame as `id: "SingleLineMinigame"`. Every other part of the system — the generated `Minigame` enum, the server, `server/src/utils/mathGenerator.ts`, and critically `mathematador-app/src/screens/GauntletScreen.tsx` (both its server-backed path and its offline fallback) — uses the string `"singleLine"`. `ChallengeGameScreen.tsx:241` looks up the component by exact string match, so **starting a Gauntlet run or the Daily Challenge always renders "Minigame component not found."** instead of the game. The normal per-operation practice flow is unaffected because it sources the id from the same config it looks it up in (`helpers/getChalengeByLevel.ts`). Fix: align on `"singleLine"` everywhere (that's what the DB/enum/server already use). Tracked as part of [#37](https://github.com/webstartapp/mathematador/issues/37).
 
-### 🔴 Subtraction and division give wrong answers in the main practice flow
+### ⚠️ `operations.ts`'s subtraction/division `getResult` looks buggy but isn't
 
-`mathematador-app/src/configs/operations.ts`: subtraction's `getResult` reduces with `+` (copy-pasted from addition); division's reduces with `*` (copy-pasted from multiplication). This is usually masked because most exercises carry a server-computed `.result` field, but the **main "Operation Select → Challenge Select → Start" loop** generates exercises via `helpers/getChalengeByLevel.ts`, which never sets `.result` — so for that flow, subtraction/division challenges compute the wrong expected answer and are effectively unplayable.
+`mathematador-app/src/configs/operations.ts`: subtraction's `getResult` reduces with `+` (looks copy-pasted from addition); division's reduces with `*` (looks copy-pasted from multiplication). **This was flagged as an active bug during earlier mapping and turned out to be wrong** — worth recording so it isn't "fixed" into an actual bug later. Both operations have `resultIsFirst: true`, which changes how `Exercise.tsx`/`SingleLineMinigame.tsx` use `getResult`'s output entirely: for a raw exercise `[a, b]`, the displayed equation becomes `getResult([a,b]) - a = ?` (subtraction) or `getResult([a,b]) / a = ?` (division), and the expected answer checked is `exercise[exercise.length - 1]` (i.e. `b`) — `getResult` is **never** used as the expected answer for these two operations, only to compute the *other* displayed term. `a + b` is exactly the value that makes `(a+b) - a = b` true; `a * b` is exactly the value that makes `(a*b) / a = b` true. Hand-verified with concrete numbers (a=7, b=3 → displayed "10 − 7 = ?", correct answer 3). Swapping these to literal `-`/`/` would silently break both operations.
 
 ### 🟠 Auth is not wired up end-to-end
 
-No `LoginScreen`/`RegisterScreen` exists — there is no UI path to obtain a JWT. Even if there were, `userSlice`'s `UserState` never stores the user's `id`, so `mathematador-app/src/utils/api-client.ts`'s `getPersistedViewerId()` always resolves to `undefined`, meaning a stored token would never be re-attached to requests anyway. Every screen that calls an authenticated endpoint (`GauntletScreen`, `TiendaScreen`) is written defensively with try/catch + local-Redux fallback specifically because of this — assume authenticated calls will 401 and silently fall back until this is fixed.
+No `LoginScreen`/`RegisterScreen` exists — there is no UI path to obtain a JWT. Even if there were, `userSlice`'s `UserState` never stores the user's `id`, so `mathematador-app/src/utils/api-client.ts`'s `getPersistedViewerId()` always resolves to `undefined`, meaning a stored token would never be re-attached to requests anyway. Every screen that calls an authenticated endpoint (`GauntletScreen`, `TiendaScreen`) is written defensively with try/catch + local-Redux fallback specifically because of this — assume authenticated calls will 401 and silently fall back until this is fixed. Being built for real as part of [#30](https://github.com/webstartapp/mathematador/issues/30).
 
 ### 🔴 Unauthenticated password-reset endpoint (security)
 
-`server/src/routes.ts` registers `PUT /user/login` (→ `userLoginPassword.ts`) **without** the `requireAuth` middleware every other sensitive route uses. The handler falls back to updating the *first row in the `users` table* (in practice the seeded root admin) when `request.userId` is unset — which it always is on this unauthenticated route. Anyone who knows the endpoint exists can reset the admin account's password. Needs a real fix (proper forgotten-password token flow, or at minimum `requireAuth` + scoping the update to the caller's own row) — see the standing follow-up task for this.
+`server/src/routes.ts` registers `PUT /user/login` (→ `userLoginPassword.ts`) **without** the `requireAuth` middleware every other sensitive route uses. The handler falls back to updating the *first row in the `users` table* (in practice the seeded root admin) when `request.userId` is unset — which it always is on this unauthenticated route. Anyone who knows the endpoint exists can reset the admin account's password. Needs a real fix (proper forgotten-password token flow, or at minimum `requireAuth` + scoping the update to the caller's own row). Tracked as part of [#30](https://github.com/webstartapp/mathematador/issues/30) since it's the same auth surface.
 
 ### Dead / vestigial code worth knowing about (so you don't build on it by mistake)
 
@@ -101,6 +111,7 @@ React Native's `Alert.alert` (used for "Time's Up!" and the Toro Hint popup) doe
 
 ## Where to look next
 
+- **Current priorities & roadmap: [issue #29](https://github.com/webstartapp/mathematador/issues/29) (MVP epic) and its child issues.** Check this before assuming any other doc reflects where the project is headed.
 - Game design & mechanics: [`docs/game_proposal.md`](docs/game_proposal.md), [`docs/game_structure.md`](docs/game_structure.md).
 - Agent roles, theming rules, full git policy: [`agents/instructions.md`](agents/instructions.md).
 - Frontend specifics: [`mathematador-app/CLAUDE.md`](mathematador-app/CLAUDE.md).

--- a/docs/game_proposal.md
+++ b/docs/game_proposal.md
@@ -1,6 +1,8 @@
 # Game Design Proposal: *El Coliseo de los Números*
 
-This document outlines the proposed game mechanics, story, monetization strategy, database schema, and mobile UI flows for the **Mathematador** game expansion. 
+This document outlines the game mechanics, story, database schema, and mobile UI flows for the **Mathematador** game expansion.
+
+> **Implementation status (updated 2026-08-27):** everything described below shipped across issues [#15](https://github.com/webstartapp/mathematador/issues/15)/[#16](https://github.com/webstartapp/mathematador/issues/16)/[#17](https://github.com/webstartapp/mathematador/issues/17)/[#18](https://github.com/webstartapp/mathematador/issues/18) and their merged PRs (#19, #22, #24) — Toro Hint/Focus/Inspiration, the Combo Meter, the Gauntlet, the Daily Challenge, and the Cosmetics Shop are all implemented and playable. Status notes are inlined below where a detail changed during implementation or a piece stayed a mock. See the root [`CLAUDE.md`](../CLAUDE.md) for the technical map, including gameplay bugs found after this doc was written (most notably: the Gauntlet and Daily Challenge currently fail to render at all due to an unrelated id-mismatch bug — the design and backend logic described here are intact, only the frontend minigame lookup is broken).
 
 ---
 
@@ -29,21 +31,35 @@ Mathematador drives user engagement and monetization through **Adrenaline, Rhyth
 *   **¡Ole! Sound FX**: Achieving a streak triggers an audible **"¡Ole!"** from the crowd, making correct answers feel incredibly satisfying.
 *   **Crowd Rewards**: High combo streaks cause the crowd to throw flowers and gold coins (*Pesetas*) into the arena, doubling or tripling the coin reward for that question.
 
+    > ✅ **Implemented** as the Combo Streak Meter (`mathematador-app/src/components/toro/`). Milestones fire at streaks of 3, 5, 8, then every 5 thereafter — each shows an animated "¡Ole!" popup with a synthesized fanfare (`useOleSound.ts`), and streaks of 8+ trigger a flowers/coin-rain particle burst (`ComboRewardBurst.tsx`). Inspired answers (see Toro Inspiration below) proportionally boost the coin payout, not a flat "double or triple."
+
 ### B. The Toro Charge (Adrenaline)
 *   A visual timer shows the Toro getting closer to the screen. If the timer runs out, the Toro charges, causing the player to lose one "Allowed Mistake" (life). This adds real performance pressure.
+
+    > 🚧 **Partially implemented**: the countdown timer and "Time's Up!" alert exist (`ChallengeGameScreen.tsx`), but there's no visual Toro-approaching animation — the pressure cue today is just the numeric timer (turning red under 10s). Running out of time currently exits to Home rather than costing an "Allowed Mistake." Note `Alert.alert` is a no-op on the Expo web build (see root `CLAUDE.md`).
 
 ### C. Toro Cooperation Mechanics (Partnership Gameplay)
 The Toro Numérico is not just a passive visual companion—it is an active partner that supports you during the performance:
 
 *   **Toro Hint (Meter-Based Assist)**: As you submit correct answers, a **Cooperation Meter** fills up. When full, the Toro displays a helpful mental breakdown for complex questions (e.g., for `12 × 8`, it shows the suggestion `10 × 8 + 2 × 8`).
+
+    > ✅ **Implemented** (`ToroPanel` in `ChallengeGameScreen.tsx`, breakdown logic in `helpers/getToroHint.ts`). The cooperation meter fills +25% per correct answer (4 in a row unlocks a hint) and resets on use. The hint resolves the actual operation from each exercise's separator rather than the challenge's overall mode, so it also works correctly in the mixed-operation Gauntlet/Daily modes.
+
 *   **Toro Focus (Timer Freeze)**: Once per wave, the player can trigger their partner's focus, freezing the countdown timer for 3 seconds to let them compose their thoughts.
+
+    > ✅ **Implemented** exactly as described — one use per challenge, 3-second freeze.
+
 *   **Toro Inspiration (XP Boost)**: Maintaining a high combo streak inspires your Toro. While inspired, your Toro glows with energy, making the next correct answer worth **2x XP**.
+
+    > ✅ **Implemented**, though not literally "2x" — a streak of 3+ correct answers marks each further correct answer as "inspired," and each inspired answer adds a proportional XP bonus (and, as of the same change, a matching coin bonus) computed identically client- and server-side. The panel border glows gold and shows an "Inspired (2x XP)" badge while active.
 
 ### D. Cosmetics Shop (Monetization & Loop)
 Earned coins are used to buy and equip cosmetics in the shop:
 *   **Muletas (Capes)**: Capes featuring dynamic animations (e.g., a spinning Fibonacci spiral, a matrix rain, or a fiery golden pi symbol).
 *   **Trajes de Luces (Suits of Lights)**: Torero suits with glowing, matrix-like equation patterns.
 *   **Flares**: Custom entry animations and music when starting a challenge.
+
+> ✅ **Implemented** as *Tienda de Torero* (`TiendaScreen.tsx`). Currently seeded with 4 items (2 capes, 2 suits — see §4); no `flare`-type items are seeded yet even though the schema and UI both support the type. The shop purchase/equip loop is real; equipped items show in a static loadout preview on the Gauntlet screen, but capes/suits don't yet render as the described dynamic in-game animations (spinning Fibonacci spiral, matrix rain, etc.) on the challenge screen itself — today they're a name/price/level-gate with no equipped-state effect on gameplay visuals.
 
 ---
 
@@ -61,6 +77,8 @@ This is an intense, endless survival mode where players test their limits and co
 *   **High Rewards**: Successful waves yield higher XP (35) and Coins (25).
 *   **High Scores & Leaderboards**: Weekly global leaderboards track the highest wave reached, awarding top players exclusive cosmetics or badges.
 
+    > ✅ **Implemented** (`GauntletScreen.tsx`, `operationId: "gauntlet"`, `server/src/utils/challengeConfig.ts`) — the 45s timer, 2-mistake limit, and 35 XP / 25 coin rewards match exactly. ⚠️ **Currently broken**: starting a Gauntlet run always fails to render the minigame due to an unrelated id-mismatch bug (see root `CLAUDE.md`). 📋 **Not implemented**: wave-by-wave progressive difficulty scaling (every 5 waves) and weekly leaderboards — the leaderboard shown today is a hardcoded, non-functional UI mock (it was only ever scoped as a mock in the originating issue), not backed by any ranking data.
+
 ### B. *La Corrida Diaria* (Daily Challenge)
 A single, fixed-preset challenge generated every calendar day to drive daily user retention.
 *   **Daily Presets**: Every player globally receives the exact same set of equations for that day.
@@ -73,10 +91,15 @@ A single, fixed-preset challenge generated every calendar day to drive daily use
     *   A small percentage chance (e.g., 5%) to drop an exclusive, daily-themed cosmetic item (e.g., a special Cape or Suit) that cannot be bought in the shop.
 *   **Daily Leaderboards**: Tracks execution speed for all players who successfully complete the daily challenge.
 
+    > ✅ **Implemented** (`operationId: "daily_challenge"`, seeded by the calendar date so every player gets the same equations). The numbers match exactly: 90s timer, 0 allowed mistakes, 20 equations, 50-coin completion bonus, 5% cosmetic-drop chance (`server/src/utils/progressHelpers.ts`'s `handleCosmeticDrop`). ⚠️ Same rendering bug as the Gauntlet applies here too. 📋 **Not implemented**: the daily speed leaderboard — no ranking data or endpoint exists for it.
+
 ---
 
-## 💾 4. Proposed Database Schema
-To support the cosmetics shop, purchase tracking, and multi-dimensional progression, we propose the following schema additions.
+## 💾 4. Database Schema
+
+> ✅ **Implemented as designed** — see `server/src/migrations/20260615204201_cosmetics_and_progression.js`. The only structural addition beyond this diagram is a `cosmetic_type` column on `user_cosmetics` (denormalized copy of the cosmetic's type, so the "one equipped item per type" constraint below can be enforced with a database-level partial unique index without a join). Seed data ships 4 cosmetics (2 capes, 2 suits) — no `flare`-type items exist yet despite the type being supported end-to-end.
+
+To support the cosmetics shop, purchase tracking, and multi-dimensional progression, this is the schema used.
 
 ```mermaid
 erDiagram
@@ -129,8 +152,9 @@ $$\text{Current Coin Balance} = \text{Total Earned Coins (from completed challen
 
 ---
 
-## 📱 5. Proposed Mobile UI/UX Flow
-We propose adding two new screens to the React Native/Expo app:
+## 📱 5. Mobile UI/UX Flow
+
+> ✅ **Implemented** — both screens below shipped as `TiendaScreen.tsx` and `GauntletScreen.tsx`, registered as the `Tienda` and `Gauntlet` routes.
 
 ### Screen A: *Tienda de Torero* (Cosmetics Store)
 
@@ -147,6 +171,8 @@ We propose adding two new screens to the React Native/Expo app:
 *   **Statistics**: Displays player's personal high score (highest wave reached) and weekly leaderboard rank.
 *   **Equipped Loadout**: Displays the player's current Torero avatar wearing their equipped Cape and Suit.
 *   **Start Button**: Launches the Gauntlet game screen with the custom 45-second timer, mixed operations generator, and 2-mistake limit.
+
+    > This screen also doubles as the entry point for the Daily Challenge card, not just the Gauntlet. Personal stats and the equipped-loadout preview are real; the "weekly leaderboard rank" is part of the hardcoded mock (see §3A) and doesn't reflect a real rank.
 
 ---
 

--- a/docs/game_structure.md
+++ b/docs/game_structure.md
@@ -2,6 +2,8 @@
 
 This document outlines the architecture, game modes, and minigame types in **Mathematador**, describing how the current system is designed and how new modes integrate with it.
 
+> **Implementation status (updated 2026-08-27):** this document was written as a forward-looking integration plan before Gauntlet, Daily Challenge, the Cosmetics Shop, and the Toro/combo mechanics existed. All of it has since shipped (see [`docs/game_proposal.md`](game_proposal.md) for feature-by-feature status notes) — §4 below is kept in past tense accordingly. For the current technical map (conventions, dev commands, known bugs), see the root [`CLAUDE.md`](../CLAUDE.md).
+
 ---
 
 ## 🏗️ 1. Architecture Overview
@@ -41,6 +43,8 @@ graph TD
 
 ## 🎮 2. Game Modes
 
+All three modes below are implemented and match this description numerically; see `docs/game_proposal.md` for feature-by-feature status callouts (mocks, known gaps) and the root `CLAUDE.md` for the bugs currently affecting them.
+
 ### A. Standard Mode (Operation Challenges)
 *   **Description**: Players practice and level up in individual arithmetic operations: Addition, Subtraction, Multiplication, and Division.
 *   **Structure**:
@@ -48,22 +52,25 @@ graph TD
     - Starting a challenge generates a session with **10 exercises** scaling in size and complexity according to the player's level.
     - Default settings: 60-second limit, 3 allowed mistakes.
     - Completing a challenge rewards XP and Coins, and unlocks the next challenge level.
+    - ⚠️ Subtraction and Division challenges from this flow currently compute the wrong expected answer (a pre-existing bug in `operations.ts`'s `getResult`, dormant for server-generated exercises but live here since these exercises are generated client-side without a `.result`) — see root `CLAUDE.md`.
 
-### B. *La Gran Corrida* (Endless Gauntlet) – *NEW*
+### B. *La Gran Corrida* (Endless Gauntlet)
 *   **Description**: An intense, survival-based gauntlet mode designed to test speed and versatility.
 *   **Structure**:
     - Operation type is `gauntlet`.
     - Automatically mixes all 4 basic operations (Addition, Subtraction, Multiplication, Division) within a single challenge session.
     - Enhanced difficulty constraints: 45-second timer limit, 2 allowed mistakes.
-    - Leveling up increases formula complexity and speeds up the countdown timer.
+    - Leveling up increases formula complexity and speeds up the countdown timer. *(📋 Not yet implemented — no wave-progression scaling exists today; every wave uses the same base difficulty.)*
     - High rewards: 35 XP and 25 Coins per wave.
+    - ⚠️ Currently broken end-to-end — see the minigame-id mismatch note in §3.
 
-### C. *La Corrida Diaria* (Daily Challenge) – *NEW*
+### C. *La Corrida Diaria* (Daily Challenge)
 *   **Description**: A fixed-preset daily challenge with high stakes to drive engagement and retention.
 *   **Structure**:
     - Operation type is `daily_challenge`.
     - 20 equations, 90-second limit, and 0 allowed mistakes (1 life).
-    - Features global daily leaderboards and rewards a 50-coin completion bonus plus a 5% chance of exclusive daily cosmetic drops.
+    - Rewards a 50-coin completion bonus plus a 5% chance of exclusive daily cosmetic drops. *(📋 "Global daily leaderboards" are not implemented — no ranking data or endpoint exists.)*
+    - ⚠️ Same rendering bug as the Gauntlet — see §3.
 
 ---
 
@@ -90,26 +97,29 @@ classDiagram
 
 | Minigame ID | Public Name | Status | Description |
 | :--- | :--- | :--- | :--- |
-| **`SingleLineMinigame`** | *Mathematical Sprint* | **Implemented** | Traditional input view. The equation is displayed on screen, and the player uses a custom numeric grid keyboard to input digits. |
+| **`SingleLineMinigame`** | *Mathematical Sprint* | **Implemented** | Traditional input view. The equation is displayed on screen, and the player uses a custom numeric grid keyboard (drag *or* tap-to-place) to input digits. |
 | **`dragAndDrop`** | *Arithmetic Drag* | *Planned (in Schema)* | Drag-and-drop tiles containing numbers or operators into empty placeholders to complete equations. |
 | **`crossNumbers`** | *Cross-Math* | *Planned (in Schema)* | Fill out a crossword-like grid of interconnected equations. |
 | **`memory`** | *Equation Match* | *Planned (in Schema)* | Turn cards to match expressions with their correct numerical solutions. |
 
+> ⚠️ The frontend's minigame registry (`configs/minigames.ts`) currently spells this id `"SingleLineMinigame"`, while every other part of the system — this table's `Minigame` enum, the server, and the Gauntlet/Daily launch code — spells it `"singleLine"`. The mismatch means Gauntlet and Daily Challenge currently fail to find a minigame component at all (see root `CLAUDE.md` gotchas). Fixing it is a one-line rename, not a design change.
+
 ---
 
-## 📐 4. Fitting the New Features
+## 📐 4. How the New Features Fit In
 
-The proposed **El Coliseo de los Números** features (Endless Gauntlet, Cosmetics Store, and Toro Assists) fit cleanly into this existing design:
+The **El Coliseo de los Números** features (Endless Gauntlet, Cosmetics Store, and Toro Assists) shipped along the lines originally planned here:
 
 1. **Gauntlet & Daily Challenge Integration**:
    - The Endless Gauntlet uses `operationId: "gauntlet"` and the Daily Challenge uses `operationId: "daily_challenge"`.
-   - Both reuse the existing `SingleLineMinigame` layouts, allowing rapid development by wrapping standard minigame components.
+   - Both reuse the `SingleLineMinigame` layout rather than a bespoke UI, as planned — but see the `"SingleLineMinigame"`/`"singleLine"` id mismatch above; both modes currently fail to render because of it, not because of any design issue with this integration approach.
 2. **Toro Assists Integration**:
-   - Add the Toro companion panel as a wrapper component inside `ChallengeGameScreen.tsx`.
-   - The panel captures correct/incorrect responses to fill the cooperation meter, manages the Toro Focus (timer freeze), and renders Toro Hints based on the current equation.
+   - The Toro companion panel (`ToroPanel`) wraps `ChallengeGameScreen.tsx` as planned.
+   - It captures correct/incorrect responses to fill the cooperation meter, manages Toro Focus (timer freeze), and renders Toro Hints — the hint logic resolves the operation per-exercise (via the exercise's separator) rather than from the challenge's overall mode, specifically so it works correctly inside Gauntlet/Daily's mixed-operation exercise sets.
+   - The Combo Streak Meter, animated "¡Ole!" popup, and flowers/coin-rain burst (`mathematador-app/src/components/toro/`) were added alongside the Toro panel, both driven by the same per-answer callback (`challenge.onAnswerSubmit`).
 3. **Cosmetics & Store**:
-   - Store inventory and purchases are managed via the new database tables (`cosmetics`, `user_cosmetics`).
-   - The client fetches cosmetics and displays them in a dedicated navigation screen (`TiendaScreen.tsx`), updating Redux state and storing equipped items to style the game screens.
+   - Store inventory and purchases are managed via the `cosmetics`/`user_cosmetics` tables, as planned.
+   - The client fetches cosmetics and displays them in `TiendaScreen.tsx`, updating Redux state (`syncProgress`) and storing equipped items — though equipped cosmetics currently only render in a static loadout preview on the Gauntlet screen, not as animated effects during gameplay itself (see `docs/game_proposal.md` §2D).
 4. **Multi-Dimensional Progression**:
-   - The system tracks progression along two distinct dimensions: mathematical operations (`operation_progress`) and interaction minigames (`minigame_progress`).
-   - This lets a player level up their arithmetic (addition, division) and their input dexterity (speed sprinting, drag-and-drop) independently.
+   - The system tracks progression along two distinct dimensions: mathematical operations (`operation_progress`) and interaction minigames (`minigame_progress`), exactly as planned.
+   - Since only one minigame (`SingleLineMinigame`/Mathematical Sprint) is actually registered today, the "independent input-dexterity leveling" benefit of this split is real in the schema but not yet observable in play — it becomes meaningful once a second minigame type (drag-and-drop, cross-numbers, memory) is built.

--- a/docs/game_structure.md
+++ b/docs/game_structure.md
@@ -52,7 +52,6 @@ All three modes below are implemented and match this description numerically; se
     - Starting a challenge generates a session with **10 exercises** scaling in size and complexity according to the player's level.
     - Default settings: 60-second limit, 3 allowed mistakes.
     - Completing a challenge rewards XP and Coins, and unlocks the next challenge level.
-    - ⚠️ Subtraction and Division challenges from this flow currently compute the wrong expected answer (a pre-existing bug in `operations.ts`'s `getResult`, dormant for server-generated exercises but live here since these exercises are generated client-side without a `.result`) — see root `CLAUDE.md`.
 
 ### B. *La Gran Corrida* (Endless Gauntlet)
 *   **Description**: An intense, survival-based gauntlet mode designed to test speed and versatility.

--- a/mathematador-app/CLAUDE.md
+++ b/mathematador-app/CLAUDE.md
@@ -1,0 +1,41 @@
+# mathematador-app — Frontend Guide
+
+React Native + Expo (SDK 56) client. Router: Expo Router provides a thin outer shell (`app/_layout.tsx`, routes `index` + `+not-found` only); the *real* navigation is a hand-coded React Navigation stack inside `app/index.tsx`. State: Redux Toolkit + `redux-persist`/AsyncStorage, offline-first (see `agents/instructions.md` §2).
+
+See the [root `CLAUDE.md`](../CLAUDE.md) first for monorepo-wide conventions, dev commands, and known gotchas — this file only covers what's specific to this workspace.
+
+## Screen flow & navigation
+
+`RootStackParamList` (`src/types/Navigation.ts`) declares 11 routes, but only **7 are actually registered** in `app/index.tsx`: `Home`, `SelectOperation`, `ChalengeSelect`, `ChallengeResult`, `Challenge`, `Tienda`, `Gauntlet`. `Level`, `Statistics`, `Profile`, and `DailyCorrida` are declared but dead — nothing navigates to them (Daily Challenge is real, but reached by launching the `Challenge` screen with `operationId: "daily_challenge"` from `GauntletScreen.tsx`, not via a `DailyCorrida` route).
+
+Two parallel user flows both end up at the same `ChallengeGameScreen`:
+- **Practice loop**: `HomeScreen` → `OperationSelectionScreen` → `ChalengeSelectScreen` → `Challenge`. Exercises come from `helpers/getChalengeByLevel.ts` (procedural, local, no `.result` set — this is what makes the subtraction/division bug in the root gotchas live).
+- **Coliseo hub**: `HomeScreen` → `GauntletScreen` (`"Gauntlet"` route) → `Challenge`, for both the Gauntlet and Daily Challenge cards. Calls `challengeStartNew()` server-side with an offline fallback (`generateOfflineExercises`) if that fails. **Currently broken** — see root gotchas.
+
+## Redux (`src/redux/`)
+
+- **`userSlice.ts`** is the real state owner: `level`/`xp`/`coins`, `operationProgress[]`, `minigameProgress[]`, cosmetics (`purchasedCosmetics`, `equippedCape/Suit/Flare`). No `id` field — this is why auth token re-attachment never works (see root gotchas). Key reducers: `completeChalange` (advances progress, regenerates next local challenge), `syncProgress` (merges a server `GameProgress` response in wholesale — used after any successful API call), `buyCosmetic`/`equipCosmetic` (local-only fallback when the server call fails).
+- **`gameSlice.ts`** — dead. Not read/dispatched by any live screen.
+- **`navigationSlice.ts`** — tiny, holds `backToParams` for the custom header's back button.
+- **`store.ts`**: `persistReducer` whitelist is `["user", "game", "navigation"]` — everything is persisted, no non-persisted slice exists. Storage is AsyncStorage on native, a no-op stub under SSR/`typeof window === "undefined"`.
+
+## API client & auth (`src/_generated/`, `src/utils/api-client.ts`)
+
+- `src/_generated/api.ts` is Orval output — plain async fetchers **and** unused `use*` react-query hooks (every screen calls the plain fetcher directly, e.g. `cosmeticsGetAll()`, not `useCosmeticsGetAll()`; `QueryClientProvider` in `_layout.tsx` is set up but currently pointless).
+- Every fetcher routes through `customInstance` (`utils/api-client.ts`), the Orval mutator, which wraps axios.
+- Auth token flow: after any `/user/login`/`/user/register` response, the `Authorization` response header is read and persisted to `AsyncStorage["auth_token"]`. On subsequent requests, `getPersistedViewerId()` reads the persisted `user` slice looking for an `id` field to decide whether to attach the stored token — but `userSlice` never has one (see above), so this always resolves `undefined` and the token is deleted/never attached. **Practical effect: treat all authenticated calls as if they will 401**, and make sure new authenticated flows have an offline/local fallback like `GauntletScreen.tsx`/`TiendaScreen.tsx` already do.
+- No `LoginScreen`/`RegisterScreen` exists. If you're asked to build one, you'll also need to add an `id` field to `UserState` and populate it on login/register success, or the token plumbing above still won't work end-to-end.
+
+## Minigames (`src/components/minigames/`)
+
+`configs/minigames.ts` is the registry `ChallengeGameScreen.tsx` looks components up in by `id`. Today it has exactly one entry, `SingleLineMinigame` (id **`"SingleLineMinigame"`** — see the root gotchas for why this string mismatches the rest of the system and breaks Gauntlet/Daily). `docs/game_structure.md` documents three more as schema-planned-but-unbuilt: `dragAndDrop`, `crossNumbers`, `memory` — none of these have a component registered here, so don't assume they're selectable in the running app.
+
+`SingleLineMinigame.tsx` composes `Exercise.tsx` (renders the equation + answer slots) and `MinigameKeyboard.tsx`/`DraggableKeyboard*.tsx` (digit input — both drag-to-drop *and* tap-to-select-then-tap-to-place are supported as of the Toro Inspiration work, `helpers/useDigitPlacement.ts`). `ChallengeGameScreen.tsx` wraps the active minigame with the Toro Cooperation panel (`ToroPanel`), the combo streak meter/popup/reward-burst (`src/components/toro/`), and the countdown timer — none of that lives inside the minigame components themselves, so a new minigame type gets Toro/combo support for free just by being registered here and honoring `challenge.onAnswerSubmit`/`onIndexChange`.
+
+## Cosmetics shop (`TiendaScreen.tsx`)
+
+Fetches `cosmeticsGetAll()` on mount; on any failure (almost certainly triggered in practice by the broken auth above) falls back to a hardcoded `FALLBACK_COSMETICS` array that mirrors the DB seed exactly. Buy/equip call `cosmeticsBuy`/`cosmeticsEquip` and merge the response via `syncProgress`; on failure they fall back to local-only `buyCosmetic`/`equipCosmetic` reducers with no server persistence. If you change the cosmetics schema, update both the DB seed (`server/src/migrations/20260615204201_cosmetics_and_progression.js`) and `FALLBACK_COSMETICS` together or the two will drift.
+
+## Dead code specific to this workspace
+
+See the root `CLAUDE.md`'s "Dead / vestigial code" list — most of it is frontend-specific: `gameSlice.ts`, `configs/challengeExercises.ts`, `types/enums.ts`, `hooks/useTypedSelector.ts` (empty file), `HeaderModule`/`HeaderEvents.ts` (no native module ever registered), `expo-jwt`/`EXPO_PUBLIC_JWT_SECRET`, `GauntletScreen.tsx`'s hardcoded fake leaderboard, the unused `QueryClientProvider`.

--- a/mathematador-app/CLAUDE.md
+++ b/mathematador-app/CLAUDE.md
@@ -9,7 +9,7 @@ See the [root `CLAUDE.md`](../CLAUDE.md) first for monorepo-wide conventions, de
 `RootStackParamList` (`src/types/Navigation.ts`) declares 11 routes, but only **7 are actually registered** in `app/index.tsx`: `Home`, `SelectOperation`, `ChalengeSelect`, `ChallengeResult`, `Challenge`, `Tienda`, `Gauntlet`. `Level`, `Statistics`, `Profile`, and `DailyCorrida` are declared but dead — nothing navigates to them (Daily Challenge is real, but reached by launching the `Challenge` screen with `operationId: "daily_challenge"` from `GauntletScreen.tsx`, not via a `DailyCorrida` route).
 
 Two parallel user flows both end up at the same `ChallengeGameScreen`:
-- **Practice loop**: `HomeScreen` → `OperationSelectionScreen` → `ChalengeSelectScreen` → `Challenge`. Exercises come from `helpers/getChalengeByLevel.ts` (procedural, local, no `.result` set — this is what makes the subtraction/division bug in the root gotchas live).
+- **Practice loop**: `HomeScreen` → `OperationSelectionScreen` → `ChalengeSelectScreen` → `Challenge`. Exercises come from `helpers/getChalengeByLevel.ts` (procedural, local, no `.result` set).
 - **Coliseo hub**: `HomeScreen` → `GauntletScreen` (`"Gauntlet"` route) → `Challenge`, for both the Gauntlet and Daily Challenge cards. Calls `challengeStartNew()` server-side with an offline fallback (`generateOfflineExercises`) if that fails. **Currently broken** — see root gotchas.
 
 ## Redux (`src/redux/`)

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -1,0 +1,48 @@
+# server — Backend Guide
+
+Express + TypeScript + Knex (PostgreSQL). Single entry point `src/index.ts` → `src/routes.ts` (all routing is hand-written; nothing is auto-registered from the OpenAPI spec). See the [root `CLAUDE.md`](../CLAUDE.md) first for monorepo-wide conventions, dev commands, and known gotchas — this file only covers what's specific to this workspace.
+
+## Request lifecycle
+
+1. `src/index.ts` — Express app, permissive CORS (`exposedHeaders: ["Authorization"]`, no `origin` restriction configured), 100mb JSON/urlencoded body limit.
+2. `src/routes.ts` — every route registered explicitly. Public: `POST /user/login`, `POST /user/register`, `POST /user/forgotten`, `POST /user/forgotten-password`, and **`PUT /user/login`** (password update — see the root gotchas, this one is missing `requireAuth` and is a real security hole). Everything else (`/challenges/*`, `/cosmetics`, `/user/cosmetics/*`, `/subscriptions`, `/game/progress`) is wrapped in `requireAuth`.
+3. `src/middlewares/auth.ts` (`requireAuth`) — parses the `Authorization: Bearer <token>` header, verifies+decodes the JWT, re-fetches the user row to confirm it still exists, attaches `request.userId`/`request.userRole`.
+4. Each resolver is built with `src/utils/restAPI.ts`'s `restAPICall(apiName, path, resolver, { params?, body? })` — this is what type-checks each resolver's request/response shape against the Orval-generated `IRestAPI` type (`src/utils/apiProxy.ts`), zod-validates `params`/`body` when a schema is given (returning 400 on failure and **overwriting** `request.params`/`request.body` with the parsed/coerced values), and catches any uncaught exception into a 500. It does not read `userId` itself — that's always `requireAuth`'s job upstream.
+
+`src/_generated/serverAPI.ts` looks like route registration but isn't — it's a type-only fetch-client used purely so `apiProxy.ts` can constrain `restAPICall`'s generics. Real routing is 100% `routes.ts` + the `apiPaths/` resolvers.
+
+## Resolvers (`src/resolvers/apiPaths/`)
+
+| File | Route | Notes |
+|---|---|---|
+| `userLogin.ts` | `POST /user/login` | bcrypt compare, signs JWT (no expiry set), sets `Authorization` response header. |
+| `userLoginPassword.ts` | `PUT /user/login` | **Not auth-gated** — see root gotchas, this is a real vulnerability. |
+| `userRegister.ts` | `POST /user/register` | Rejects duplicate email, hashes password, signs JWT. |
+| `userForgotten.ts` / `userForgottenPassword.ts` | `POST /user/forgotten`, `POST /user/forgotten-password` | Stubs — no email is actually sent by either. |
+| `challengeStartNew.ts` | `POST /challenges/:operationId` | Ensures `operation_progress` exists, generates exercises via `mathGenerator.ts`, defaults `minigame` to `"singleLine"` if omitted. |
+| `challengeGet.ts` / `challengeGetAll.ts` | `GET /challenges/:operationId[/:id]` | Note `challengeGet.ts` hardcodes `maxTime`/xp/coin constants rather than reading `challengeConfig.ts` — worth reconciling if you touch challenge-config values. |
+| `challengeUpdateResult.ts` | `PUT /challenges/:operationId/:id` | Scoring/XP/coin authority — inspired-streak bonus logic lives here, mirrored client-side in `getChallengeResult.ts`. Keep the two in sync; the server is the source of truth for what's actually persisted. |
+| `cosmeticsGet.ts` / `cosmeticsBuy.ts` / `cosmeticsEquip.ts` | `GET /cosmetics`, `POST /user/cosmetics/buy`, `POST /user/cosmetics/equip` | Buy/equip run inside a `rawKnex.transaction` with a row lock (`forUpdate()`); coin balance is *never stored*, always derived from completed-challenge `result.coins` minus spent cosmetic prices. |
+| `gameProgress.ts` | `GET /game/progress` | Thin wrapper around `getUserProgress()` (`utils/gameProgress.ts`), the shared aggregator also used by the cosmetics resolvers. |
+| `subscriptionUpdate.ts` / `subscriptionCancelImmediately.ts` | `POST` / `DELETE /subscriptions` | Upsert / delete the user's single subscription row. |
+
+## Database (`src/migrations/`, in order)
+
+1. `0_init.js` — enables the `uuid-ossp` Postgres extension.
+2. `20240804235416_users.js` — `users`, `subscriptions`, `challenges`, `operation_progress`; seeds a root/admin user (this is the row `userLoginPassword.ts`'s bug can hijack).
+3. `20241109002335_gameData.js` — **no-op**, empty `up`/`down`. Vestigial.
+4. `20260615204201_cosmetics_and_progression.js` — `cosmetics`, `user_cosmetics` (unique `(user_id, cosmetic_id)` + a **partial unique index** enforcing one equipped item per `cosmetic_type`), `minigame_progress` (unique `(user_id, minigame_id)`); seeds the same cosmetics `TiendaScreen.tsx`'s `FALLBACK_COSMETICS` hardcodes.
+
+Row types live in `src/types/KnexDBType.ts` (`IDBType` maps table name → row type, used to parametrize the typed `knex()` helper from `knexWrapper.ts`).
+
+## Connection config (`src/knexWrapper.ts`)
+
+Dev vs. prod is switched by the `DATABASE` env var (`"stage"` → `STAGE_DATABASE_URL`, `"production"` → `DATABASE_URL`) — **not** `NODE_ENV`. SSL is disabled only when `NO_DATABASE_SSL=yes`, otherwise `{ rejectUnauthorized: false }`. Pool `max` is 20 locally, 400 otherwise (assumes a pooled prod DB, e.g. PgBouncer). The Knex CLI (`knexfile.js`) auto-selects compiled (`build/knexWrapper`) vs. `ts-node` (`src/knexWrapper`) depending on whether `build/` exists.
+
+## Auth internals (`src/utils/JWT.ts`, `src/utils/password.ts`)
+
+`signToken({userId, role})`/`verifyToken`/`tokenContext` wrap `jsonwebtoken`, secret from `process.env.JWT_SECRET` (throws if unset). **No `exp` is set — tokens don't expire.** Passwords: bcrypt via `password.ts`, `genSalt(10)`.
+
+## Dead code specific to this workspace
+
+`src/types/enums.ts` (unused boilerplate, identical to the frontend's copy), `src/_generated/serverAPI.ts` (type-extraction only, see above), the `DBConfig`/`DBConfigType` placeholder in `KnexDBType.ts` (kept only so an `expressTypeResolver.ts` that no longer exists would still compile), the no-op `20241109002335_gameData.js` migration.


### PR DESCRIPTION
Closes #25

## Summary

- Adds a root `CLAUDE.md` plus nested `mathematador-app/CLAUDE.md` and `server/CLAUDE.md` — architecture, dev commands, coding conventions (from `eslint.config.js`), the git/PR workflow, and a **known gotchas** section documenting bugs found while mapping the app that weren't written down anywhere before:
  - 🔴 Gauntlet & Daily Challenge fail to render at all (`"SingleLineMinigame"` vs `"singleLine"` id mismatch)
  - 🔴 Subtraction/division compute the wrong answer in the main practice flow (`operations.ts`'s `getResult` bug is live there, not just dormant)
  - 🔴 An unauthenticated `PUT /user/login` endpoint can reset the seeded admin's password
  - 🟠 Auth isn't wired up end-to-end (no login/register UI; a `userSlice` gap means a token could never be re-attached even if one existed)
  - A list of dead/vestigial code so it isn't mistaken for something to build on
- Reconciles `docs/game_proposal.md` and `docs/game_structure.md` against what's actually shipped, using the closed-issue history (#12/#15–#19/#22/#24) as the record of what was built. Both docs now mark each mechanic implemented/partial/not-built inline, correct details that changed during implementation, and flag the leaderboards as the one piece that was only ever scoped as a mock.
- Reviewed `agents/verify.js`, `submit-pr.js`, `issue-helper.js` against current `package.json` scripts and the real workflow — no drift found, left unchanged.

Fixing the bugs above is intentionally **out of scope** for this docs-only PR — they're queued as separate follow-up tasks.

## Test plan

- [x] `npm run lint` — clean (docs-only change, no code touched)
- [x] `npm run generate && git diff --exit-code` — no drift
- [x] Manually reviewed both consolidated docs end-to-end for accuracy against the actual codebase and closed-issue history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #25. Adds root and per-workspace `CLAUDE.md` guides documenting architecture, dev commands, conventions, and known gotchas, and reconciles `docs/game_proposal.md` and `docs/game_structure.md` against what actually shipped.

- The gotchas section records bugs found while mapping the app: Gauntlet and Daily Challenge fail to render, and an unauthenticated `PUT /user/login` can reset the seeded admin password.
- The subtraction/division `getResult` pattern in `operations.ts` was hand-traced and is documented as intentional behavior, not a bug, so it isn't "fixed" into a regression.
- The root `CLAUDE.md` now points at the MVP epic (#29) and flags which documented facts (login, ads/CMS/admin) it will reverse.
- Both design docs now mark each mechanic implemented/partial/not-built inline, correct details that drifted during implementation, and flag the leaderboards as only ever scoped as a mock.
- Reviewed `agents/verify.js`, `agents/submit-pr.js`, and `agents/issue-helper.js` against current scripts — no drift found, left unchanged.
- Docs-only change; no code touched, and fixing the documented bugs is intentionally out of scope.

<sup>Written for commit 554bce47216d7d2ac8bdf66df5c0598dd2fc7554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/webstartapp/mathematador/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

