### PR TITLE
Resolve Issue #48: zero out mathematador-app's tsc --noEmit errors

### DIFF
--- a/mathematador-app/src/components/ExternalLink.tsx
+++ b/mathematador-app/src/components/ExternalLink.tsx
@@ -1,9 +1,11 @@
-import { Link } from "expo-router";
+import { ExternalPathString, Link } from "expo-router";
 import { openBrowserAsync } from "expo-web-browser";
 import { JSX, type ComponentProps } from "react";
 import { Platform } from "react-native";
 
-type Props = Omit<ComponentProps<typeof Link>, "href"> & { href: string };
+type Props = Omit<ComponentProps<typeof Link>, "href"> & {
+  href: ExternalPathString;
+};
 
 export const ExternalLink = ({ href, ...rest }: Props): JSX.Element => {
   return (

--- a/mathematador-app/src/components/common/Header.tsx
+++ b/mathematador-app/src/components/common/Header.tsx
@@ -17,14 +17,10 @@ import { levelOperationUp, levelUserUp } from "@/src/redux/slices/userSlice";
 import { RootStackParamList } from "@/types/Navigation";
 
 type HeaderProps = {
-  backTo?: keyof RootStackParamList;
+  backTo?: "Home";
   showOperation?: boolean;
   props: StackHeaderProps;
 };
-
-type LooseNavigationProp = StackNavigationProp<
-  Record<string, Record<string, string | number | undefined>>
->;
 
 const GameHeader: FC<HeaderProps> = ({
   backTo,
@@ -48,7 +44,7 @@ const GameHeader: FC<HeaderProps> = ({
     handleMeasurement();
   }, []);
 
-  const navigation = useNavigation<LooseNavigationProp>();
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const { backToParams } = useSelector((state: RootState) => state.navigation);
 
   const { level, xp, xpToNextLevel, operationProgress } = useSelector(

--- a/mathematador-app/src/components/layouts/CenteredDesk.tsx
+++ b/mathematador-app/src/components/layouts/CenteredDesk.tsx
@@ -52,14 +52,20 @@ const localStyles = StyleSheet.create({
   },
 });
 
-type LocalStylesType = typeof localStyles;
+type CenteredDeskStyleOverrides = Partial<{
+  wrapper: ViewStyle;
+  container: ViewStyle;
+  title: TextStyle;
+  subtitle: TextStyle;
+  description: TextStyle;
+}>;
 
 const CenteredDesk: FC<{
   title: string;
   subtitles?: string[];
   descriptions?: string[];
   children?: ReactNode;
-  styles?: Partial<Record<keyof LocalStylesType, ViewStyle | TextStyle>>;
+  styles?: CenteredDeskStyleOverrides;
 }> = ({ title, subtitles, descriptions, children, styles }) => {
   return (
     <View style={[localStyles.wrapper, styles?.wrapper]}>

--- a/mathematador-app/src/components/texts/ThemedText.tsx
+++ b/mathematador-app/src/components/texts/ThemedText.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from "react";
-import { StyleSheet, Text, TextProps } from "react-native";
+import { StyleSheet, Text, TextProps, TextStyle } from "react-native";
 
 const applyStylesFN = <T extends string>(
-  styles: StyleSheet.NamedStyles<Record<T, string>>,
-): StyleSheet.NamedStyles<Record<T, string>> => styles;
+  styles: Record<T, TextStyle>,
+): Record<T, TextStyle> => styles;
 
 const themedStyles = applyStylesFN({
   title: {

--- a/mathematador-app/src/redux/slices/userSlice.ts
+++ b/mathematador-app/src/redux/slices/userSlice.ts
@@ -93,15 +93,20 @@ const syncMinigames = (
   if (!payloadMinigames) {
     return [];
   }
-  return payloadMinigames.map((minigameItem) => {
+  const minigameProgress: MinigameProgress[] = [];
+  payloadMinigames.forEach((minigameItem) => {
+    if (minigameItem.minigameId === undefined) {
+      return;
+    }
     const levelVal = minigameItem.level ?? 1;
-    return {
+    minigameProgress.push({
       minigameId: minigameItem.minigameId,
       level: levelVal,
       xp: minigameItem.xp ?? 0,
       xpToNextLevel: calculateXPToNextLevel(levelVal),
-    };
+    });
   });
+  return minigameProgress;
 };
 
 const userSlice = createSlice({

--- a/mathematador-app/src/screens/ChallengeGameScreen.tsx
+++ b/mathematador-app/src/screens/ChallengeGameScreen.tsx
@@ -28,12 +28,23 @@ import { useOleSound } from "@/components/toro/useOleSound";
 import { minigames } from "@/configs/minigames";
 import { completeChalange, syncProgress } from "@/redux/slices/userSlice";
 import { challengeUpdateResult } from "@/src/_generated/api";
+import { OperationId } from "@/src/_generated/model";
 import {
   Challenge,
   ChalengeResult,
   Exercise as ExerciseType,
 } from "@/types/Chalenge";
 import { RootStackParamList } from "@/types/Navigation";
+
+const toOperationId = (value: string): OperationId | undefined => {
+  if (value === "addition") return value;
+  if (value === "subtraction") return value;
+  if (value === "multiplication") return value;
+  if (value === "division") return value;
+  if (value === "gauntlet") return value;
+  if (value === "daily_challenge") return value;
+  return undefined;
+};
 
 type ChallengeScreenRouteProp = RouteProp<RootStackParamList, "Challenge">;
 type ChallengeScreenNavigationProps = StackNavigationProp<
@@ -292,7 +303,10 @@ const ChallengeGameScreen = (): JSX.Element => {
     result: ChalengeResult,
   ): Promise<void> => {
     try {
-      const operationId = challenge.operationId;
+      const operationId = toOperationId(challenge.operationId);
+      if (!operationId) {
+        throw new Error(`Unknown operationId: ${challenge.operationId}`);
+      }
       const challengeIdStr = String(challenge.challengeId);
       const response = await challengeUpdateResult(
         operationId,

--- a/mathematador-app/src/utils/api-client.ts
+++ b/mathematador-app/src/utils/api-client.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import axios, { AxiosRequestConfig } from "axios";
+import axios, { AxiosResponse } from "axios";
 import { z } from "zod";
 
 const AXIOS_INSTANCE = axios.create({
@@ -33,11 +33,6 @@ const getAuthToken = async (
   return AsyncStorage.getItem(PERSISTED_TOKEN_KEY);
 };
 
-export type CustomRequestConfig = AxiosRequestConfig & {
-  body?: string | object | number | boolean | null;
-  headers?: Record<string, string | number | boolean | undefined>;
-};
-
 const JsonValueSchema = z.union([
   z.string(),
   z.number(),
@@ -46,8 +41,6 @@ const JsonValueSchema = z.union([
   z.array(z.any()),
   z.null(),
 ]);
-
-const HeadersSchema = z.record(z.union([z.string(), z.number(), z.boolean()]));
 
 const parseJSON = (
   jsonString: string,
@@ -87,78 +80,90 @@ const getPersistedViewerId = async (): Promise<string | number | undefined> => {
 
 const ResponseHeadersSchema = z.record(z.string());
 
-const buildHeaders = (
-  configHeaders:
-    | Record<string, string | number | boolean | undefined>
-    | undefined,
-  token: string | null,
+const normalizeHeaders = (
+  headersInit: HeadersInit | undefined,
 ): Record<string, string> => {
   const headers: Record<string, string> = {};
 
-  if (configHeaders) {
-    const parsedHeaders = HeadersSchema.safeParse(configHeaders);
-    if (parsedHeaders.success) {
-      Object.keys(parsedHeaders.data).forEach((key) => {
-        const value = parsedHeaders.data[key];
-        if (value !== undefined) {
-          headers[key] = String(value);
-        }
-      });
-    }
+  if (!headersInit) {
+    return headers;
   }
+
+  if (headersInit instanceof Headers) {
+    headersInit.forEach((value, key) => {
+      headers[key] = value;
+    });
+    return headers;
+  }
+
+  const entries = Array.isArray(headersInit)
+    ? headersInit
+    : Object.entries(headersInit);
+
+  entries.forEach(([key, value]) => {
+    if (value !== undefined) {
+      headers[key] = String(value);
+    }
+  });
+
+  return headers;
+};
+
+const persistAuthTokenIfPresent = async (
+  requestUrl: string,
+  responseHeaders: AxiosResponse["headers"],
+): Promise<void> => {
+  const isAuthRequest =
+    requestUrl.includes("/user/login") || requestUrl.includes("/user/register");
+  if (!isAuthRequest) {
+    return;
+  }
+
+  const parsedHeaders = ResponseHeadersSchema.safeParse(responseHeaders);
+  if (!parsedHeaders.success) {
+    return;
+  }
+
+  const authHeader =
+    parsedHeaders.data["authorization"] ?? parsedHeaders.data["Authorization"];
+  if (!authHeader) {
+    return;
+  }
+
+  const parts = authHeader.split(" ");
+  const tokenVal = parts.length === 2 ? parts[1] : parts[0];
+  if (tokenVal) {
+    await AsyncStorage.setItem(PERSISTED_TOKEN_KEY, tokenVal);
+  }
+};
+
+// Matches the RequestInit shape orval's fetch-client codegen always passes
+// (see @orval/fetch's generated `options?: RequestInit`), translated into
+// an axios call under the hood.
+export const customInstance = async <T>(
+  requestUrl: string,
+  options: RequestInit,
+): Promise<T> => {
+  const viewerId = await getPersistedViewerId();
+  const token = await getAuthToken(viewerId);
+  const headers = normalizeHeaders(options.headers);
 
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
   }
 
-  return headers;
-};
-
-export const customInstance = async <T>(
-  requestUrl: string,
-  config: CustomRequestConfig,
-): Promise<T> => {
-  const viewerId = await getPersistedViewerId();
-  const token = await getAuthToken(viewerId);
-  const headers = buildHeaders(config.headers, token);
-
-  const { body, ...rest } = config;
-  let requestData = body;
-  if (typeof body === "string") {
-    try {
-      requestData = parseJSON(body);
-    } catch {
-      requestData = body;
-    }
-  }
+  const requestBody =
+    typeof options.body === "string" ? parseJSON(options.body) : options.body;
 
   const response = await AXIOS_INSTANCE<T>({
     url: requestUrl,
-    data: requestData,
-    ...rest,
+    method: options.method,
+    data: requestBody,
     headers,
+    signal: options.signal ?? undefined,
   });
 
-  // Extract and persist the authorization token if returned from login/register
-  if (
-    requestUrl.includes("/user/login") ||
-    requestUrl.includes("/user/register")
-  ) {
-    const parsedHeaders = ResponseHeadersSchema.safeParse(response.headers);
-    if (parsedHeaders.success) {
-      const authHeader =
-        parsedHeaders.data["authorization"] ??
-        parsedHeaders.data["Authorization"];
-
-      if (authHeader) {
-        const parts = authHeader.split(" ");
-        const tokenVal = parts.length === 2 ? parts[1] : parts[0];
-        if (tokenVal) {
-          await AsyncStorage.setItem(PERSISTED_TOKEN_KEY, tokenVal);
-        }
-      }
-    }
-  }
+  await persistAuthTokenIfPresent(requestUrl, response.headers);
 
   return response.data;
 };


### PR DESCRIPTION
Closes #48. Follow-up filed: #49 (replace axios with native fetch — out of scope here per feedback, see below).

## Summary
Root-caused and fixed all 41 pre-existing `tsc --noEmit` errors on `mathematador-app`:

- **~34 errors in the Orval-generated `src/_generated/api.ts`**: `customInstance`'s second parameter was typed as an axios-flavored `CustomRequestConfig` even though Orval's fetch-client codegen always calls it with a genuine `RequestInit`-shaped object. I initially tried setting `httpClient: "axios"` in `orval.config.ts` to match the mutator, but that changes the generated call convention entirely (single merged-config object instead of `(url, options)`) and moves the client further into axios rather than away from it. Reverted that and instead retyped `customInstance` to accept real `RequestInit` and translate it into the axios call internally — a minimal, non-breaking fix that also simplified the implementation (no more manual JSON-string body round-tripping). `npm run generate` still reproduces the committed generated files exactly (zero diff).
- **~7 errors in real source files**:
  - `CenteredDesk.tsx` / `ThemedText.tsx`: a `StyleSheet.NamedStyles` result typed as a loose `ViewStyle | TextStyle | ImageStyle` union was passed into `<Text>`/`<View>` without narrowing per slot — retyped each style slot to the style kind it's actually used with.
  - `Header.tsx`: `GameHeader`'s `backTo` prop was typed `keyof RootStackParamList` (all 11 screens), which broke `navigate()`'s overload resolution; every call site only ever passes `"Home"`, so narrowed the prop type to match reality.
  - `ExternalLink.tsx`: `href` was a bare `string`; retyped to Expo Router's `ExternalPathString` (its own type for non-internal URLs).
  - `userSlice.ts`: `syncMinigames` didn't account for the server's `minigameId` being optional; now filters out entries missing one.
  - `ChallengeGameScreen.tsx`: `Challenge.operationId` (a loose `string`) was passed into an endpoint typed against the specific `OperationId` literal union; added a narrowing helper and fall through to the existing offline-fallback `catch` for any unrecognized value.

No `as`/`is`-predicate assertions used anywhere (both banned by this repo's ESLint config) — all narrowing is via plain control-flow checks.

## Test plan
- [x] `npx tsc --noEmit -p mathematador-app/tsconfig.json` reports zero errors
- [x] `npm run generate && git diff` shows no drift in `_generated/`
- [x] `npm run lint` (repo root) clean
- [x] `npm run build --workspace=mathematador-app` and `npm run build --workspace=server` both succeed
- [x] `npm test` (server + app) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all 41 pre-existing `tsc --noEmit` errors in `mathematador-app`, so type checking now passes. Most errors came from `customInstance` accepting an axios-flavored config while Orval's fetch-client codegen always passes `RequestInit`; the rest were over-broad types, with two fixes carrying minor runtime behavior changes.

**Changes**
- `customInstance` accepts `RequestInit` and translates it into the axios call internally; the old `CustomRequestConfig` type is gone.
- `Header`'s `backTo` prop narrowed to `"Home"` (the only value call sites pass), restoring `navigate()` overload resolution.
- `ExternalLink`'s `href` is now Expo Router's `ExternalPathString` instead of a plain `string`.
- `CenteredDesk` and `ThemedText` style slots are now typed to the concrete style kind each uses (`ViewStyle` vs `TextStyle`) instead of a loose union.
- `syncMinigames` now drops server entries missing a `minigameId` instead of storing `undefined` for them.
- `ChallengeGameScreen` narrows `operationId` to the allowed `OperationId` literals, sending unrecognized values to the existing offline fallback.

No `as` or `is` assertions were introduced (both are banned by this repo's lint config); replacing axios with native fetch stays out of scope, tracked in #49.

<sup>Written for commit 950ca5ac350c18f06fef71ae284ec9be8608a4c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/webstartapp/mathematador/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

