### PR TITLE
Resolve Issue #49 (Parts 1-2): native fetch + eliminate startup warnings

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,7 @@
       "name": "mathematador-web",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["--prefix", "mathematador-app", "run", "web"],
-      "port": 8081
+      "port": 4075
     }
   ]
 }

--- a/mathematador-app/package.json
+++ b/mathematador-app/package.json
@@ -21,7 +21,6 @@
     "@react-native-async-storage/async-storage": "1.23.1",
     "@reduxjs/toolkit": "^2.6.0",
     "@tanstack/react-query": "^5.28.0",
-    "axios": "^1.8.2",
     "expo": "~56.0.11",
     "expo-audio": "~56.0.13",
     "expo-constants": "~56.0.18",

--- a/mathematador-app/src/app/_layout.tsx
+++ b/mathematador-app/src/app/_layout.tsx
@@ -13,9 +13,12 @@ import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 
 import spaceMonoFont from "@/assets/fonts/SpaceMono-Regular.ttf";
+import { silenceThirdPartyWarnings } from "@/helpers/silenceThirdPartyWarnings";
 import { store, persistor } from "@/redux/store";
 
 const queryClient = new QueryClient();
+
+silenceThirdPartyWarnings();
 
 // Prevent the splash screen from auto-hiding before asset loading is
 // complete. Deliberately NOT hidden here once fonts load - IntroScreen holds

--- a/mathematador-app/src/components/layouts/CenteredDesk.tsx
+++ b/mathematador-app/src/components/layouts/CenteredDesk.tsx
@@ -2,6 +2,9 @@ import { FC, ReactNode } from "react";
 import { StyleSheet, TextStyle, View, ViewStyle } from "react-native";
 
 import ThemedText from "@/components/texts/ThemedText";
+import { createTextShadow } from "@/helpers/createTextShadow";
+
+const bodyTextShadow = createTextShadow("black", 2, 2, 5);
 
 const localStyles = StyleSheet.create({
   container: {
@@ -11,20 +14,14 @@ const localStyles = StyleSheet.create({
     backgroundColor: "#d49b57",
     color: "#fff",
     width: "100%",
-    shadowColor: "#B47b37",
-    shadowOffset: {
-      width: 2,
-      height: 2,
-    },
+    boxShadow: [{ offsetX: 2, offsetY: 2, blurRadius: 0, color: "#B47b37" }],
   },
   wrapper: {},
   title: {
     fontSize: 30,
     marginBottom: 10,
     color: "white",
-    textShadowColor: "black",
-    textShadowOffset: { width: 2, height: 2 },
-    textShadowRadius: 5,
+    ...bodyTextShadow,
     paddingLeft: 10,
     paddingRight: 10,
   },
@@ -32,9 +29,7 @@ const localStyles = StyleSheet.create({
     fontSize: 24,
     marginBottom: 5,
     color: "white",
-    textShadowColor: "black",
-    textShadowOffset: { width: 2, height: 2 },
-    textShadowRadius: 5,
+    ...bodyTextShadow,
     textAlign: "center",
     paddingLeft: 10,
     paddingRight: 10,
@@ -43,9 +38,7 @@ const localStyles = StyleSheet.create({
     fontSize: 18,
     marginBottom: 5,
     color: "white",
-    textShadowColor: "black",
-    textShadowOffset: { width: 2, height: 2 },
-    textShadowRadius: 5,
+    ...bodyTextShadow,
     textAlign: "justify",
     paddingLeft: 10,
     paddingRight: 10,

--- a/mathematador-app/src/components/toro/ComboPopup.tsx
+++ b/mathematador-app/src/components/toro/ComboPopup.tsx
@@ -8,6 +8,8 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
+import { createTextShadow } from "@/helpers/createTextShadow";
+
 const AUTO_DISMISS_DELAY_MS = 1500;
 
 interface ComboPopupProps {
@@ -47,7 +49,9 @@ const ComboPopup = ({ comboText }: ComboPopupProps): JSX.Element => {
   }
 
   return (
-    <Animated.View style={[styles.overlay, animatedStyle]} pointerEvents="none">
+    <Animated.View
+      style={[styles.overlay, { pointerEvents: "none" }, animatedStyle]}
+    >
       <Text style={styles.text}>{displayText}</Text>
     </Animated.View>
   );
@@ -66,9 +70,7 @@ const styles = StyleSheet.create({
     fontSize: 30,
     fontWeight: "900",
     color: "#FFD700",
-    textShadowColor: "rgba(0, 0, 0, 0.75)",
-    textShadowOffset: { width: -1, height: 1 },
-    textShadowRadius: 10,
+    ...createTextShadow("rgba(0, 0, 0, 0.75)", -1, 1, 10),
   },
 });
 

--- a/mathematador-app/src/components/toro/ComboRewardBurst.tsx
+++ b/mathematador-app/src/components/toro/ComboRewardBurst.tsx
@@ -91,7 +91,7 @@ const ComboRewardBurst = ({ burstKey }: ComboRewardBurstProps): JSX.Element => {
   }
 
   return (
-    <View style={styles.overlay} pointerEvents="none">
+    <View style={[styles.overlay, { pointerEvents: "none" }]}>
       {particles.map((particleItem) => (
         <Particle
           key={particleItem.particleKey}

--- a/mathematador-app/src/helpers/createTextShadow.ts
+++ b/mathematador-app/src/helpers/createTextShadow.ts
@@ -1,0 +1,24 @@
+import { Platform, TextStyle } from "react-native";
+
+// react-native-web warns on textShadowColor/Offset/Radius (deprecated in
+// favor of a unified CSS-shorthand `textShadow` string), but React Native's
+// own shipped types don't declare that unified prop on TextStyle yet, so it
+// isn't safely typeable as a like-for-like swap - hence the platform split.
+export type TextShadowStyle = TextStyle & { textShadow?: string };
+
+export const createTextShadow = (
+  color: string,
+  offsetWidth: number,
+  offsetHeight: number,
+  radius: number,
+): TextShadowStyle =>
+  Platform.select<TextShadowStyle>({
+    web: {
+      textShadow: `${offsetWidth}px ${offsetHeight}px ${radius}px ${color}`,
+    },
+    default: {
+      textShadowColor: color,
+      textShadowOffset: { width: offsetWidth, height: offsetHeight },
+      textShadowRadius: radius,
+    },
+  });

--- a/mathematador-app/src/helpers/silenceThirdPartyWarnings.ts
+++ b/mathematador-app/src/helpers/silenceThirdPartyWarnings.ts
@@ -1,0 +1,36 @@
+// Both of these come from inside dependencies, not this app's own code, and
+// can't be fixed without patching them:
+// - react-native-paper's ProgressBar (used in Header.tsx) unconditionally
+//   requests useNativeDriver internally on several of its own animations,
+//   which react-native-web doesn't support.
+// - react-native-web's own TouchableOpacity (used throughout this app)
+//   passes `pointerEvents` as a direct prop rather than via `style` when
+//   `disabled` is set - that's react-native-web's own implementation
+//   (node_modules/react-native-web/dist/exports/TouchableOpacity/index.js),
+//   not anything this app's code does.
+// LogBox.ignoreLogs doesn't catch either on web (verified live - still
+// printed after LogBox.ignoreLogs is called), so this filters console.warn
+// directly instead.
+const KNOWN_THIRD_PARTY_WARNINGS = [
+  "useNativeDriver` is not supported because the native animated module is missing",
+  "props.pointerEvents is deprecated. Use style.pointerEvents",
+];
+
+export const silenceThirdPartyWarnings = (): void => {
+  // eslint-disable-next-line no-console
+  const originalConsoleWarn = console.warn;
+
+  // eslint-disable-next-line no-console
+  console.warn = (...warnArgs: Parameters<typeof console.warn>): void => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const [firstArg] = warnArgs;
+    const isKnownWarning =
+      typeof firstArg === "string" &&
+      KNOWN_THIRD_PARTY_WARNINGS.some((pattern) => firstArg.includes(pattern));
+
+    if (isKnownWarning) {
+      return;
+    }
+    originalConsoleWarn(...warnArgs);
+  };
+};

--- a/mathematador-app/src/providers/animations/AnimatedImage.tsx
+++ b/mathematador-app/src/providers/animations/AnimatedImage.tsx
@@ -7,7 +7,13 @@ import {
   useRef,
   ReactNode,
 } from "react";
-import { ImageSourcePropType, StyleSheet, View, Animated } from "react-native";
+import {
+  ImageSourcePropType,
+  StyleSheet,
+  View,
+  Animated,
+  Platform,
+} from "react-native";
 
 type AnimatedImageProps = {
   image: ImageSourcePropType | undefined;
@@ -26,7 +32,14 @@ export const AnimatedImage: FC<AnimatedImageProps> = ({ image }) => {
       Animated.loop(
         Animated.sequence(
           sequence.map((step) =>
-            Animated.timing(anim, { ...step, useNativeDriver: true }),
+            Animated.timing(anim, {
+              ...step,
+              // react-native-web has no native animation driver and warns
+              // on every setup that requests one - only native platforms
+              // get the perf benefit, matching this file's other Animated
+              // usages that are already platform-gated the same way.
+              useNativeDriver: Platform.OS !== "web",
+            }),
           ),
         ),
       ).start();

--- a/mathematador-app/src/screens/GauntletScreen.tsx
+++ b/mathematador-app/src/screens/GauntletScreen.tsx
@@ -353,10 +353,9 @@ const styles = StyleSheet.create({
     borderColor: "rgba(255, 255, 255, 0.1)",
     padding: 16,
     marginBottom: 20,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.15,
-    shadowRadius: 10,
+    boxShadow: [
+      { offsetX: 0, offsetY: 4, blurRadius: 10, color: "rgba(0,0,0,0.15)" },
+    ],
   },
   sectionTitle: {
     color: "#fff",

--- a/mathematador-app/src/screens/TiendaScreen.tsx
+++ b/mathematador-app/src/screens/TiendaScreen.tsx
@@ -460,10 +460,9 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     paddingVertical: 6,
     paddingHorizontal: 12,
-    shadowColor: "#FFD700",
-    shadowOffset: { width: 0, height: 0 },
-    shadowOpacity: 0.3,
-    shadowRadius: 5,
+    boxShadow: [
+      { offsetX: 0, offsetY: 0, blurRadius: 5, color: "rgba(255,215,0,0.3)" },
+    ],
   },
   coinsEmoji: {
     fontSize: 18,
@@ -492,10 +491,14 @@ const styles = StyleSheet.create({
   },
   tabActive: {
     backgroundColor: "rgba(255, 255, 255, 0.15)",
-    shadowColor: "#fff",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 3,
+    boxShadow: [
+      {
+        offsetX: 0,
+        offsetY: 2,
+        blurRadius: 3,
+        color: "rgba(255,255,255,0.1)",
+      },
+    ],
   },
   tabText: {
     color: "rgba(255, 255, 255, 0.6)",
@@ -526,17 +529,19 @@ const styles = StyleSheet.create({
     borderColor: "rgba(255, 255, 255, 0.1)",
     padding: 16,
     marginBottom: 16,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.15,
-    shadowRadius: 10,
+    boxShadow: [
+      { offsetX: 0, offsetY: 4, blurRadius: 10, color: "rgba(0,0,0,0.15)" },
+    ],
   },
   cardEquipped: {
     borderColor: "#FFD700",
     backgroundColor: "rgba(255, 215, 0, 0.05)",
-    shadowColor: "#FFD700",
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
+    // Matches `card`'s offsetY:4 - previously this only overrode
+    // shadowColor/Opacity/Radius and inherited card's shadowOffset since
+    // boxShadow replaces the whole shadow as one style key, not four.
+    boxShadow: [
+      { offsetX: 0, offsetY: 4, blurRadius: 8, color: "rgba(255,215,0,0.1)" },
+    ],
   },
   cardLocked: {
     opacity: 0.6,

--- a/mathematador-app/src/utils/api-client.ts
+++ b/mathematador-app/src/utils/api-client.ts
@@ -1,10 +1,9 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import axios, { AxiosResponse } from "axios";
 import { z } from "zod";
 
-const AXIOS_INSTANCE = axios.create({
-  baseURL: String(process.env.EXPO_PUBLIC_API_URL || "http://localhost:4076"),
-});
+const BASE_URL = String(
+  process.env.EXPO_PUBLIC_API_URL || "http://localhost:4076",
+);
 
 const PERSISTED_STATE_KEY = "persist:root";
 
@@ -33,25 +32,6 @@ const getAuthToken = async (
   return AsyncStorage.getItem(PERSISTED_TOKEN_KEY);
 };
 
-const JsonValueSchema = z.union([
-  z.string(),
-  z.number(),
-  z.boolean(),
-  z.record(z.any()),
-  z.array(z.any()),
-  z.null(),
-]);
-
-const parseJSON = (
-  jsonString: string,
-): string | object | number | boolean | null => {
-  const parsed = JsonValueSchema.safeParse(JSON.parse(jsonString));
-  if (parsed.success) {
-    return parsed.data;
-  }
-  return null;
-};
-
 const getPersistedViewerId = async (): Promise<string | number | undefined> => {
   try {
     const storage =
@@ -77,8 +57,6 @@ const getPersistedViewerId = async (): Promise<string | number | undefined> => {
   }
   return undefined;
 };
-
-const ResponseHeadersSchema = z.record(z.string());
 
 const normalizeHeaders = (
   headersInit: HeadersInit | undefined,
@@ -111,7 +89,7 @@ const normalizeHeaders = (
 
 const persistAuthTokenIfPresent = async (
   requestUrl: string,
-  responseHeaders: AxiosResponse["headers"],
+  responseHeaders: Headers,
 ): Promise<void> => {
   const isAuthRequest =
     requestUrl.includes("/user/login") || requestUrl.includes("/user/register");
@@ -119,13 +97,7 @@ const persistAuthTokenIfPresent = async (
     return;
   }
 
-  const parsedHeaders = ResponseHeadersSchema.safeParse(responseHeaders);
-  if (!parsedHeaders.success) {
-    return;
-  }
-
-  const authHeader =
-    parsedHeaders.data["authorization"] ?? parsedHeaders.data["Authorization"];
+  const authHeader = responseHeaders.get("authorization");
   if (!authHeader) {
     return;
   }
@@ -138,8 +110,7 @@ const persistAuthTokenIfPresent = async (
 };
 
 // Matches the RequestInit shape orval's fetch-client codegen always passes
-// (see @orval/fetch's generated `options?: RequestInit`), translated into
-// an axios call under the hood.
+// (see @orval/fetch's generated `options?: RequestInit`).
 export const customInstance = async <T>(
   requestUrl: string,
   options: RequestInit,
@@ -152,18 +123,26 @@ export const customInstance = async <T>(
     headers["Authorization"] = `Bearer ${token}`;
   }
 
-  const requestBody =
-    typeof options.body === "string" ? parseJSON(options.body) : options.body;
-
-  const response = await AXIOS_INSTANCE<T>({
-    url: requestUrl,
-    method: options.method,
-    data: requestBody,
+  const response = await fetch(`${BASE_URL}${requestUrl}`, {
+    ...options,
     headers,
-    signal: options.signal ?? undefined,
   });
+
+  if (!response.ok) {
+    throw new Error(
+      `Request to ${requestUrl} failed with status ${response.status}`,
+    );
+  }
 
   await persistAuthTokenIfPresent(requestUrl, response.headers);
 
-  return response.data;
+  const responseText = await response.text();
+  // The generated fetcher already types this call's result as T from the
+  // OpenAPI spec; axios's own AxiosResponse<T> typing did this same "trust
+  // the API contract" cast internally before, just hidden inside its .d.ts.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const parsedBody = responseText ? JSON.parse(responseText) : undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return parsedBody;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "@react-native-async-storage/async-storage": "1.23.1",
         "@reduxjs/toolkit": "^2.6.0",
         "@tanstack/react-query": "^5.28.0",
-        "axios": "^1.8.2",
         "expo": "~56.0.11",
         "expo-audio": "~56.0.13",
         "expo-constants": "~56.0.18",
@@ -6734,18 +6733,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/agent-cli-detector": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/agent-cli-detector/-/agent-cli-detector-0.1.6.tgz",
@@ -7106,12 +7093,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -7126,18 +7107,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
-      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.6",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -7959,18 +7928,6 @@
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -8489,15 +8446,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -8881,6 +8829,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11434,26 +11383,6 @@
       "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
       "license": "MIT"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fontfaceobserver": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
@@ -11504,43 +11433,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -11980,6 +11872,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -12119,19 +12012,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -17212,15 +17092,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pstree.remy": {


### PR DESCRIPTION
Partial progress on #49 — Parts 1 and 2 only. Part 3 (Expo Go / SDK version mismatch for mobile testing) needs a decision on build method/infra before implementing (local Android/Xcode vs. EAS cloud build for `expo-dev-client`) and isn't included here.

## Part 1 — axios → native fetch
`customInstance` already received genuine `RequestInit`-shaped options from Orval's fetch-client codegen (fixed in #48); it was still translating those into an axios call under the hood for no real reason, since RN/Expo provide `fetch` as a global on every target platform. Rewrote it to call `fetch()` directly — no more manual JSON-string body round-tripping, response header lookups simplified via `Headers.get()` (case-insensitive natively), non-2xx responses explicitly throw to preserve existing try/catch offline-fallback behavior across the app. Removed the `axios` dependency entirely.

## Part 2 — eliminate console warnings at startup
- `shadow*` → `boxShadow` (a real, typed, natively-supported RN 0.75+ prop) in `GauntletScreen.tsx`, `TiendaScreen.tsx` (×4, including a fix for `cardEquipped` silently losing its inherited `offsetY` since `boxShadow` replaces the whole shadow as one style key instead of four), `CenteredDesk.tsx`.
- `textShadow*` → `textShadow` via a new `createTextShadow()` helper. RN's own shipped types don't declare a unified `textShadow` prop on `TextStyle` yet, so this is a `Platform.select`: the real CSS-shorthand string on web, the legacy (still fully supported) props on native — typed via a small local intersection type, no `as`/`unknown` casts.
- `AnimatedImage.tsx`'s unconditional `useNativeDriver: true` is now `Platform.OS !== "web"`, matching this file's other `Animated` usages.
- Two components passed `pointerEvents="none"` as a direct prop instead of via `style` — moved into each style array.

Two warnings persisted after all of the above and were root-caused to **dependency internals, not app code** (confirmed by reading both libraries' source directly): `react-native-paper`'s `ProgressBar` unconditionally requests `useNativeDriver` on several of its own animations, and `react-native-web`'s own `TouchableOpacity` passes `pointerEvents` as a prop rather than via `style` whenever `disabled` is set. `LogBox.ignoreLogs` does not suppress either on web (verified live). `silenceThirdPartyWarnings()` filters `console.warn` directly instead, scoped to these two exact messages only.

Also fixed `.claude/launch.json`'s browser-preview port (was hardcoded to Expo's old default 8081; the app now resolves its port from `mathematador-app/.env`'s `RCT_METRO_PORT`, which is 4075 since #47).

## Test plan
- [x] `npx tsc --noEmit -p mathematador-app/tsconfig.json` — zero errors
- [x] `npm run lint` — clean
- [x] `npm run build --workspace=server` and `--workspace=mathematador-app` — both succeed
- [x] `npm test` — full suite passes
- [x] Verified live in the browser on a completely fresh tab, visiting Home → Gauntlet (exercises `GauntletScreen`'s `boxShadow`) → Tienda (exercises `TiendaScreen`'s `boxShadow` + a disabled `TouchableOpacity`) — zero shadow/textShadow/useNativeDriver/pointerEvents warnings anywhere
- [x] `npm audit` — 0 vulnerabilities before and after removing `axios`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements parts 1 and 2 of issue #49: replaces the axios-backed API client with native `fetch` and eliminates startup console warnings from deprecated style props and third-party dependencies. Non-2xx responses now throw explicitly, preserving the existing offline-fallback try/catch paths. Part 3 (Expo Go / SDK mismatch) is out of scope pending a build-method decision.

**Bug Fixes**
- Replaces deprecated `shadow*`/`textShadow*` props with `boxShadow` and a new `createTextShadow()` helper, which also fixes `cardEquipped` silently losing its inherited `offsetY`.
- Restricts `useNativeDriver` to native platforms in `AnimatedImage` and moves `pointerEvents` into style arrays in `ComboPopup` and `ComboRewardBurst`.
- Adds `silenceThirdPartyWarnings()` for two warnings originating inside `react-native-paper` and `react-native-web` that `LogBox.ignoreLogs` can't suppress on web.

**Refactors**
- Rewrites `customInstance` to call `fetch()` directly, removing manual JSON-string parsing and case-sensitive header lookups in favor of `Headers.get()`.
- Removes the `axios` dependency.
- Fixes `.claude/launch.json`'s browser-preview port to match the app's `RCT_METRO_PORT` (4075) instead of Expo's old default (8081).

<sup>Written for commit 40a38dd18c1503e094ca24dde3e6bdaa8363f5b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/webstartapp/mathematador/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

