### PR TITLE
Resolve Issue #54: fix AudioPlayer crash on intro→Home transition

### DIFF
--- a/mathematador-app/src/hooks/useMenuMusic.ts
+++ b/mathematador-app/src/hooks/useMenuMusic.ts
@@ -36,7 +36,12 @@ export const useMenuMusic = (): MenuMusicControls => {
 
   const stop = useCallback((): void => {
     wantsToPlayRef.current = false;
-    player.pause();
+    try {
+      player.pause();
+    } catch {
+      // The underlying native player may already be released if the
+      // owning screen is mid-unmount - nothing left to stop in that case.
+    }
   }, [player]);
 
   useEffect(() => {

--- a/mathematador-app/src/screens/IntroScreen.tsx
+++ b/mathematador-app/src/screens/IntroScreen.tsx
@@ -38,6 +38,11 @@ const IntroScreen = (): JSX.Element => {
   };
 
   const goToHome = (): void => {
+    // Stop the music here, deterministically, before the screen starts
+    // unmounting - relying on the effect cleanup below instead raced
+    // expo-audio's own auto-release-on-unmount and crashed (native only):
+    // the player was already released by the time cleanup called pause().
+    stopMenuMusic();
     navigation.replace("Home");
   };
 
@@ -74,9 +79,8 @@ const IntroScreen = (): JSX.Element => {
     return () => {
       clearTimeout(skipTimeoutId);
       clearTimeout(splashSafetyTimeoutId);
-      stopMenuMusic();
     };
-  }, [player, startMenuMusic, stopMenuMusic]);
+  }, [player, startMenuMusic]);
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
Closes #54.

## Summary
Reported live while testing on Android via Expo Go: `"Cannot use shared object that was already released"` thrown from `expo-audio`'s `AudioPlayer.pause()`, crashing every time the intro video ended or was skipped. Native only — never reproduced on web.

**Root cause**: `IntroScreen` called `useMenuMusic()` (which calls `expo-audio`'s `useAudioPlayer` internally) *before* its own `useEffect` whose cleanup called `stopMenuMusic()` → `player.pause()`. React runs effect cleanup in the same order effects were registered, so on unmount (triggered by `navigation.replace("Home")` in `goToHome`), `useAudioPlayer`'s own internal auto-release-on-unmount effect fired first — the native player was already released by the time the cleanup got to `pause()` it.

**Fix**: call `stopMenuMusic()` synchronously at the top of `goToHome`, before navigating away, rather than relying on unmount-cleanup ordering — `goToHome` is the single point both exit paths (video `playToEnd`, `Skip` button) already go through. Also wrapped `useMenuMusic`'s `player.pause()` in a `try/catch` as defense-in-depth against the same class of native-player-lifecycle race from any future call site.

## Test plan
- [x] `npx eslint` clean on both changed files
- [x] `npx tsc --noEmit -p mathematador-app/tsconfig.json` — 0 errors
- [x] `npm run lint`, both workspace builds, and the full test suite all pass
- [x] Live browser check: intro → Home transition, no console errors (web never reproduced the original crash, so this confirms no regression — **needs re-testing on a physical Android device via Expo Go to confirm the crash itself is gone**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the native-only crash on intro→Home transition caused by `expo-audio`'s player being auto-released before the intro's cleanup called `pause()`. Music is now stopped before navigation, and `useMenuMusic`'s `stop()` tolerates a released player. Closes #54. Web is unaffected, but this should be retested on a physical Android device.

<sup>Written for commit ec08fb352f5dacf0ecb66e3c62bd9bb1976af50f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/webstartapp/mathematador/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

