### PR TITLE
Resolve Issue #59: persistent crossfading menu music

### DIFF
--- a/mathematador-app/src/app/index.tsx
+++ b/mathematador-app/src/app/index.tsx
@@ -9,6 +9,7 @@ import { View } from "react-native";
 
 import GameHeader from "@/components/common/Header";
 import AnimatedBackgroundProvider from "@/providers/animations/AnimatedImage";
+import MenuMusicProvider from "@/providers/audio/MenuMusicProvider";
 import ChalengeSelectScreen from "@/screens/ChalengeSelectScreen";
 import ChallengeScreen from "@/screens/ChallengeGameScreen";
 import ChallengeResultScreen from "@/screens/ChallengeResultScreen";
@@ -23,102 +24,104 @@ import { RootStackParamList } from "@/types/Navigation";
 const Stack = createStackNavigator<RootStackParamList>();
 
 const IndexPage = (): JSX.Element => (
-  <AnimatedBackgroundProvider>
-    <View
-      style={{ flex: 1, backgroundColor: "transparent", width: "100%" }}
-      id="_main_layout_holder"
-    >
-      {/* Isolated from Expo Router's own NavigationContainer/linking so that
+  <MenuMusicProvider>
+    <AnimatedBackgroundProvider>
+      <View
+        style={{ flex: 1, backgroundColor: "transparent", width: "100%" }}
+        id="_main_layout_holder"
+      >
+        {/* Isolated from Expo Router's own NavigationContainer/linking so that
           gameplay navigation (Home, SelectOperation, Challenge, ...) never
           leaks screen names into the browser URL - the app must stay a SPA
           at "/" during play (issue #33). Without this, React Navigation's
           default path serialization writes every nested screen name into
           the URL since this stack has no linking config of its own. */}
-      <NavigationIndependentTree>
-        <NavigationContainer>
-          <Stack.Navigator
-            initialRouteName="Intro"
-            screenOptions={{
-              headerShown: false,
-            }}
-          >
-            <Stack.Screen
-              name="Intro"
-              component={IntroScreen}
-              options={{
+        <NavigationIndependentTree>
+          <NavigationContainer>
+            <Stack.Navigator
+              initialRouteName="Intro"
+              screenOptions={{
                 headerShown: false,
               }}
-            />
-            <Stack.Screen
-              name="Home"
-              component={HomeScreen}
-              options={{
-                headerShown: true,
-                header: (props: StackHeaderProps) => (
-                  <GameHeader props={props} />
-                ),
-              }}
-            />
-            <Stack.Screen
-              name="SelectOperation"
-              component={OperationSelectionScreen}
-              options={{
-                headerShown: true,
-                header: (props: StackHeaderProps) => (
-                  <GameHeader backTo="Home" props={props} />
-                ),
-              }}
-            />
-            <Stack.Screen
-              name="ChalengeSelect"
-              component={ChalengeSelectScreen}
-              options={{
-                headerShown: true,
-                header: (props: StackHeaderProps) => (
-                  <GameHeader backTo="Home" showOperation props={props} />
-                ),
-              }}
-            />
-            <Stack.Screen
-              name="ChallengeResult"
-              component={ChallengeResultScreen}
-              options={{
-                headerShown: true,
-                header: (props: StackHeaderProps) => (
-                  <GameHeader backTo="Home" showOperation props={props} />
-                ),
-              }}
-            />
-            <Stack.Screen
-              name="Challenge"
-              component={ChallengeScreen}
-              options={{
-                headerShown: true,
-                header: (props: StackHeaderProps) => (
-                  <GameHeader backTo="Home" showOperation props={props} />
-                ),
-              }}
-            />
-            <Stack.Screen
-              name="Tienda"
-              component={TiendaScreen}
-              options={{
-                headerShown: false,
-              }}
-            />
-            <Stack.Screen
-              name="Gauntlet"
-              component={GauntletScreen}
-              options={{
-                headerShown: false,
-              }}
-            />
-            {/* Add other screens here */}
-          </Stack.Navigator>
-        </NavigationContainer>
-      </NavigationIndependentTree>
-    </View>
-  </AnimatedBackgroundProvider>
+            >
+              <Stack.Screen
+                name="Intro"
+                component={IntroScreen}
+                options={{
+                  headerShown: false,
+                }}
+              />
+              <Stack.Screen
+                name="Home"
+                component={HomeScreen}
+                options={{
+                  headerShown: true,
+                  header: (props: StackHeaderProps) => (
+                    <GameHeader props={props} />
+                  ),
+                }}
+              />
+              <Stack.Screen
+                name="SelectOperation"
+                component={OperationSelectionScreen}
+                options={{
+                  headerShown: true,
+                  header: (props: StackHeaderProps) => (
+                    <GameHeader backTo="Home" props={props} />
+                  ),
+                }}
+              />
+              <Stack.Screen
+                name="ChalengeSelect"
+                component={ChalengeSelectScreen}
+                options={{
+                  headerShown: true,
+                  header: (props: StackHeaderProps) => (
+                    <GameHeader backTo="Home" showOperation props={props} />
+                  ),
+                }}
+              />
+              <Stack.Screen
+                name="ChallengeResult"
+                component={ChallengeResultScreen}
+                options={{
+                  headerShown: true,
+                  header: (props: StackHeaderProps) => (
+                    <GameHeader backTo="Home" showOperation props={props} />
+                  ),
+                }}
+              />
+              <Stack.Screen
+                name="Challenge"
+                component={ChallengeScreen}
+                options={{
+                  headerShown: true,
+                  header: (props: StackHeaderProps) => (
+                    <GameHeader backTo="Home" showOperation props={props} />
+                  ),
+                }}
+              />
+              <Stack.Screen
+                name="Tienda"
+                component={TiendaScreen}
+                options={{
+                  headerShown: false,
+                }}
+              />
+              <Stack.Screen
+                name="Gauntlet"
+                component={GauntletScreen}
+                options={{
+                  headerShown: false,
+                }}
+              />
+              {/* Add other screens here */}
+            </Stack.Navigator>
+          </NavigationContainer>
+        </NavigationIndependentTree>
+      </View>
+    </AnimatedBackgroundProvider>
+  </MenuMusicProvider>
 );
 
 export default IndexPage;

--- a/mathematador-app/src/hooks/useMenuMusic.ts
+++ b/mathematador-app/src/hooks/useMenuMusic.ts
@@ -1,9 +1,8 @@
-import { useAudioPlayer } from "expo-audio";
-import { useCallback, useEffect, useRef } from "react";
-import { Platform } from "react-native";
+import { useCallback } from "react";
 import { useSelector } from "react-redux";
 
 import menuThemeAsset from "@/assets/music/menu-theme.mp3";
+import { useMenuMusicContext } from "@/providers/audio/MenuMusicProvider";
 import { RootState } from "@/redux/store";
 
 interface MenuMusicControls {
@@ -11,57 +10,20 @@ interface MenuMusicControls {
   stop: () => void;
 }
 
-// Browsers block audio autoplay until the page has seen a user gesture, so a
-// bare play() call on mount is silently ignored on a cold load. Retrying on
-// the first interaction (any click/tap/keypress) is the standard workaround.
-const FIRST_INTERACTION_EVENTS = ["pointerdown", "keydown", "touchstart"];
-
 export const useMenuMusic = (): MenuMusicControls => {
   const musicEnabled = useSelector(
     (state: RootState) => state.user.musicEnabled,
   );
-  const player = useAudioPlayer(menuThemeAsset);
-  const wantsToPlayRef = useRef(false);
-
-  useEffect(() => {
-    player.loop = true;
-  }, [player]);
+  const { requestTrack } = useMenuMusicContext();
 
   const start = useCallback((): void => {
     if (!musicEnabled) return;
-    wantsToPlayRef.current = true;
-    player.seekTo(0);
-    player.play();
-  }, [musicEnabled, player]);
+    requestTrack(menuThemeAsset);
+  }, [musicEnabled, requestTrack]);
 
   const stop = useCallback((): void => {
-    wantsToPlayRef.current = false;
-    try {
-      player.pause();
-    } catch {
-      // The underlying native player may already be released if the
-      // owning screen is mid-unmount - nothing left to stop in that case.
-    }
-  }, [player]);
-
-  useEffect(() => {
-    if (Platform.OS !== "web") return () => {};
-
-    const retryOnInteraction = (): void => {
-      if (wantsToPlayRef.current && player.paused) {
-        player.play();
-      }
-    };
-
-    FIRST_INTERACTION_EVENTS.forEach((eventName) =>
-      document.addEventListener(eventName, retryOnInteraction),
-    );
-    return () => {
-      FIRST_INTERACTION_EVENTS.forEach((eventName) =>
-        document.removeEventListener(eventName, retryOnInteraction),
-      );
-    };
-  }, [player]);
+    requestTrack(null);
+  }, [requestTrack]);
 
   return { start, stop };
 };

--- a/mathematador-app/src/providers/audio/MenuMusicProvider.tsx
+++ b/mathematador-app/src/providers/audio/MenuMusicProvider.tsx
@@ -1,0 +1,86 @@
+import { AudioSource } from "expo-audio";
+import {
+  createContext,
+  FC,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+} from "react";
+import { Platform } from "react-native";
+
+import {
+  createMenuMusicEngine,
+  MenuMusicEngine,
+} from "@/providers/audio/menuMusicEngine";
+
+// Browsers block audio autoplay until the page has seen a user gesture, so a
+// bare play() call is silently ignored on a cold load. Retrying on the first
+// interaction (any click/tap/keypress) is the standard workaround.
+const FIRST_INTERACTION_EVENTS = ["pointerdown", "keydown", "touchstart"];
+
+interface MenuMusicContextValue {
+  requestTrack: (source: AudioSource | null) => void;
+}
+
+const MenuMusicContext = createContext<MenuMusicContextValue>({
+  requestTrack: () => {},
+});
+
+export const useMenuMusicContext = (): MenuMusicContextValue =>
+  useContext(MenuMusicContext);
+
+interface MenuMusicProviderProps {
+  children: ReactNode;
+}
+
+const MenuMusicProvider: FC<MenuMusicProviderProps> = ({ children }) => {
+  const engineRef = useRef<MenuMusicEngine | null>(null);
+
+  const getEngine = useCallback((): MenuMusicEngine => {
+    if (!engineRef.current) {
+      engineRef.current = createMenuMusicEngine();
+    }
+    return engineRef.current;
+  }, []);
+
+  const requestTrack = useCallback(
+    (source: AudioSource | null): void => {
+      getEngine().requestTrack(source);
+    },
+    [getEngine],
+  );
+
+  useEffect(() => {
+    if (Platform.OS !== "web") return () => {};
+
+    const retryOnInteraction = (): void => {
+      getEngine().retryPlaybackOnInteraction();
+    };
+
+    FIRST_INTERACTION_EVENTS.forEach((eventName) =>
+      document.addEventListener(eventName, retryOnInteraction),
+    );
+    return () => {
+      FIRST_INTERACTION_EVENTS.forEach((eventName) =>
+        document.removeEventListener(eventName, retryOnInteraction),
+      );
+    };
+  }, [getEngine]);
+
+  useEffect(() => {
+    return () => {
+      engineRef.current?.teardown();
+      engineRef.current = null;
+    };
+  }, []);
+
+  return (
+    <MenuMusicContext.Provider value={{ requestTrack }}>
+      {children}
+    </MenuMusicContext.Provider>
+  );
+};
+
+export default MenuMusicProvider;

--- a/mathematador-app/src/providers/audio/menuMusicEngine.ts
+++ b/mathematador-app/src/providers/audio/menuMusicEngine.ts
@@ -1,0 +1,122 @@
+import { AudioPlayer, AudioSource, createAudioPlayer } from "expo-audio";
+
+const CROSSFADE_DURATION_MS = 1000;
+const FADE_TICK_INTERVAL_MS = 50;
+const TARGET_VOLUME = 1;
+
+export interface MenuMusicEngine {
+  requestTrack: (source: AudioSource | null) => void;
+  retryPlaybackOnInteraction: () => void;
+  teardown: () => void;
+}
+
+const getTrackKey = (source: AudioSource | null): string | null =>
+  source === null ? null : JSON.stringify(source);
+
+const releaseSlot = (player: AudioPlayer): void => {
+  try {
+    player.remove();
+  } catch {
+    // Native player may already be gone - nothing left to release.
+  }
+};
+
+const createSlot = (): AudioPlayer => {
+  const player = createAudioPlayer(null);
+  player.loop = true;
+  player.volume = 0;
+  return player;
+};
+
+export const createMenuMusicEngine = (): MenuMusicEngine => {
+  let slots: [AudioPlayer, AudioPlayer] | null = null;
+  let activeSlotIndex: 0 | 1 = 0;
+  let currentTrackKey: string | null = null;
+  let fadeIntervalId: ReturnType<typeof setInterval> | null = null;
+
+  const ensureSlots = (): [AudioPlayer, AudioPlayer] => {
+    if (!slots) {
+      slots = [createSlot(), createSlot()];
+    }
+    return slots;
+  };
+
+  const stepToward = (current: number, target: number): number => {
+    const step = FADE_TICK_INTERVAL_MS / CROSSFADE_DURATION_MS;
+    if (current < target) return Math.min(target, current + step);
+    if (current > target) return Math.max(target, current - step);
+    return target;
+  };
+
+  const tick = (): void => {
+    const currentSlots = ensureSlots();
+    let allAtTarget = true;
+
+    currentSlots.forEach((player, slotIndex) => {
+      const isActive =
+        slotIndex === activeSlotIndex && currentTrackKey !== null;
+      const target = isActive ? TARGET_VOLUME : 0;
+      const nextVolume = stepToward(player.volume, target);
+
+      if (nextVolume !== player.volume) {
+        player.volume = nextVolume;
+      }
+      if (nextVolume === 0 && !isActive && player.playing) {
+        player.pause();
+      }
+      if (nextVolume !== target) {
+        allAtTarget = false;
+      }
+    });
+
+    if (allAtTarget && fadeIntervalId !== null) {
+      clearInterval(fadeIntervalId);
+      fadeIntervalId = null;
+    }
+  };
+
+  const beginFade = (): void => {
+    if (fadeIntervalId !== null) return;
+    fadeIntervalId = setInterval(tick, FADE_TICK_INTERVAL_MS);
+  };
+
+  const requestTrack = (source: AudioSource | null): void => {
+    const trackKey = getTrackKey(source);
+    if (trackKey === currentTrackKey) return;
+    currentTrackKey = trackKey;
+
+    const currentSlots = ensureSlots();
+    if (source !== null) {
+      const incomingIndex: 0 | 1 = activeSlotIndex === 0 ? 1 : 0;
+      const incomingPlayer = currentSlots[incomingIndex];
+      incomingPlayer.pause();
+      incomingPlayer.replace(source);
+      incomingPlayer.seekTo(0);
+      incomingPlayer.loop = true;
+      incomingPlayer.volume = 0;
+      incomingPlayer.play();
+      activeSlotIndex = incomingIndex;
+    }
+    beginFade();
+  };
+
+  const retryPlaybackOnInteraction = (): void => {
+    if (currentTrackKey === null || !slots) return;
+    const activePlayer = slots[activeSlotIndex];
+    if (activePlayer.paused) {
+      activePlayer.play();
+    }
+  };
+
+  const teardown = (): void => {
+    if (fadeIntervalId !== null) {
+      clearInterval(fadeIntervalId);
+      fadeIntervalId = null;
+    }
+    slots?.forEach(releaseSlot);
+    slots = null;
+    currentTrackKey = null;
+  };
+
+  return { requestTrack, retryPlaybackOnInteraction, teardown };
+};

--- a/mathematador-app/src/providers/audio/menuMusicEngine.ts
+++ b/mathematador-app/src/providers/audio/menuMusicEngine.ts
@@ -55,6 +55,16 @@ export const createMenuMusicEngine = (): MenuMusicEngine => {
     currentSlots.forEach((player, slotIndex) => {
       const isActive =
         slotIndex === activeSlotIndex && currentTrackKey !== null;
+
+      if (isActive && !player.playing) {
+        // Autoplay may have been silently blocked (e.g. no user gesture yet
+        // on web) - hold the fade-in until playback genuinely starts, so the
+        // crossfade happens relative to when audio is actually audible, not
+        // to wall-clock time since the request was made.
+        allAtTarget = false;
+        return;
+      }
+
       const target = isActive ? TARGET_VOLUME : 0;
       const nextVolume = stepToward(player.volume, target);
 
@@ -105,6 +115,7 @@ export const createMenuMusicEngine = (): MenuMusicEngine => {
     const activePlayer = slots[activeSlotIndex];
     if (activePlayer.paused) {
       activePlayer.play();
+      beginFade();
     }
   };
 

--- a/mathematador-app/src/screens/IntroScreen.tsx
+++ b/mathematador-app/src/screens/IntroScreen.tsx
@@ -23,7 +23,7 @@ const SPLASH_SAFETY_TIMEOUT_MS = 4000;
 
 const IntroScreen = (): JSX.Element => {
   const navigation = useNavigation<IntroScreenNavigationProp>();
-  const { start: startMenuMusic, stop: stopMenuMusic } = useMenuMusic();
+  const { start: startMenuMusic } = useMenuMusic();
   const [showSkip, setShowSkip] = useState(false);
   const splashHiddenRef = useRef(false);
 
@@ -38,11 +38,6 @@ const IntroScreen = (): JSX.Element => {
   };
 
   const goToHome = (): void => {
-    // Stop the music here, deterministically, before the screen starts
-    // unmounting - relying on the effect cleanup below instead raced
-    // expo-audio's own auto-release-on-unmount and crashed (native only):
-    // the player was already released by the time cleanup called pause().
-    stopMenuMusic();
     navigation.replace("Home");
   };
 


### PR DESCRIPTION
Closes #59.

## Summary
Menu music restarted from position 0 on every screen navigation because `useMenuMusic()` called `useAudioPlayer(menuThemeAsset)` — a new native player scoped to whichever component called the hook. `IntroScreen` and `HomeScreen` each called it independently, so Intro→Home, Home→SelectOperation→Home, etc. destroyed and recreated the player every time: same track, hard cut, hard restart.

## Fix
Moved player ownership into a persistent app-root provider (mirroring the existing `AnimatedBackgroundProvider` pattern, mounted at `IndexPage` level so it never unmounts during in-app navigation):

- `providers/audio/menuMusicEngine.ts`: plain-TS engine (no React) owning two alternating `createAudioPlayer` slots (`createAudioPlayer`, unlike `useAudioPlayer`, doesn't auto-release on a component's unmount). `requestTrack(source)` no-ops if the requested track is already the active one — true silent continuation, not even a fade, when e.g. Home requests the same menu theme Intro already has playing. A genuinely different track (or `null`/stop) instead drives a ~1s crossfade: a single fade loop recomputes every slot's target volume fresh each tick, so a request that interrupts an in-flight fade just reverses direction cleanly instead of glitching or leaving two players audible.
- `providers/audio/MenuMusicProvider.tsx`: context + provider wiring the engine to a lazy ref (so creation order doesn't matter under dev StrictMode's double-invoke), preserving the existing web-autoplay-retry-on-first-interaction behavior verbatim (moved from the old hook to one global listener instead of one per screen instance).
- `useMenuMusic.ts`: rewritten as a thin adapter over the provider's context, keeping its exact external `{start, stop}` shape — `HomeScreen.tsx` needed no changes at all.
- `IntroScreen.tsx`: removed the `stopMenuMusic()` call from `goToHome`. It was necessary in the old design to dodge the #54 unmount-release race, but in the new design it would reintroduce a subtler version of that same bug: fading to silence in `goToHome` then fading back up moments later in Home's mount effect, instead of the seamless continuation that's the actual point of this fix.

This also structurally eliminates the #54 crash class rather than just carrying its workaround forward: the only two `AudioPlayer` instances now live inside a provider that never unmounts during navigation, so screens never hold a player reference to race against.

## Test plan
- [x] `npm run lint` clean, `npx tsc --noEmit -p mathematador-app/tsconfig.json` clean
- [x] Live in the browser preview: Intro→Home produces zero extra network fetches of `menu-theme.mp3` (confirming the same-track no-op) and no new console errors
- [x] Home→SelectOperation→Home round trip (exercising stop-then-restart) is equally clean
- [x] `npm run build --workspace=server` and `--workspace=mathematador-app` both succeed
- [x] `npm test` — server 8/8, app 1/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #59: menu music now persists across screen navigation instead of restarting from position 0. Previously, every screen that called `useMenuMusic()` created its own player via `useAudioPlayer`; the player now lives in an app-root `MenuMusicProvider` that owns two alternating `createAudioPlayer` slots and never unmounts during navigation.

**Details**
- Requesting the track that's already playing is a no-op, so the same menu theme continues without even a fade.
- A different track or a stop request triggers a ~1s crossfade; interrupting an in-flight fade reverses direction cleanly, and the fade-in holds until playback actually starts (covered for web cold loads where autoplay is blocked).
- `useMenuMusic` keeps its `{start, stop}` shape, so `HomeScreen` needed no changes.
- Removed the `stopMenuMusic()` call from `IntroScreen.goToHome`; it would fade to silence and back up moments later, defeating the seamless continuation.
- Players no longer live inside screens, structurally eliminating the #54 crash class where a screen's unmount raced `expo-audio`'s auto-release.

<sup>Written for commit 5a7006723b40b41ea127b778ba712c8331fb43af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/webstartapp/mathematador/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

