### PR TITLE
Fix production web build shipping with a hardcoded localhost API URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,8 @@ jobs:
           [ -n "${{ secrets.SERVER_HOST }}" ]         || { echo "ERROR: SERVER_HOST is not set"; exit 1; }
           [ -n "${{ secrets.SERVER_PASSWORD }}" ]     || { echo "ERROR: SERVER_PASSWORD is not set"; exit 1; }
           [ -n "${{ secrets.SERVER_ENV_FILE }}" ]     || { echo "ERROR: SERVER_ENV_FILE is not set"; exit 1; }
-          [ -n "${{ secrets.GUI_ENV_FILE }}" ]        || { echo "ERROR: GUI_ENV_FILE is not set"; exit 1; }
           [ -n "${{ secrets.PM2_APP_NAME }}" ]        || { echo "ERROR: PM2_APP_NAME is not set"; exit 1; }
+          [ -n "${{ secrets.EXPO_PUBLIC_API_URL }}" ] || { echo "ERROR: EXPO_PUBLIC_API_URL is not set"; exit 1; }
           echo "All required secrets are set"
 
       - name: Install zip and sshpass
@@ -49,6 +49,14 @@ jobs:
 
 
       - name: Build app (Expo Web)
+        # expo export -p web inlines EXPO_PUBLIC_* vars into the static JS
+        # bundle at this exact step - there is no mathematador-app/.env in
+        # this checkout (it's gitignored) and no later step can retroactively
+        # fix a value baked in wrong here, so these must come from secrets,
+        # not a copied .env file (see issue #51).
+        env:
+          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
+          EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID }}
         run: npm run build --workspace=mathematador-app
 
       - name: Prepare stage folder
@@ -96,15 +104,20 @@ jobs:
             rm deploy.zip
           ENDSSH
 
-      - name: Copy environment files on server
+      - name: Copy environment file on server
+        # Only the server's .env is load-bearing here - it's a running Node
+        # process that reads env at startup/runtime via dotenv. The web
+        # build has no equivalent: EXPO_PUBLIC_* vars are already baked into
+        # the static bundle by the "Build app (Expo Web)" step above, and
+        # `serve` (the static file server PM2 runs for the GUI) never reads
+        # a .env file at all - see issue #51.
         env:
           SSHPASS: ${{ secrets.SERVER_PASSWORD }}
         run: |
           sshpass -e ssh -o StrictHostKeyChecking=no ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} bash -se << 'ENDSSH'
             set -e
             cp "${{ secrets.SERVER_ENV_FILE }}" "${{ secrets.DEPLOY_PATH }}/server/.env"
-            cp "${{ secrets.GUI_ENV_FILE }}" "${{ secrets.DEPLOY_PATH }}/web/.env"
-            echo "Server and GUI .env files copied"
+            echo "Server .env file copied"
           ENDSSH
 
       - name: Install server production dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,8 @@ jobs:
           [ -n "${{ secrets.SERVER_HOST }}" ]         || { echo "ERROR: SERVER_HOST is not set"; exit 1; }
           [ -n "${{ secrets.SERVER_PASSWORD }}" ]     || { echo "ERROR: SERVER_PASSWORD is not set"; exit 1; }
           [ -n "${{ secrets.SERVER_ENV_FILE }}" ]     || { echo "ERROR: SERVER_ENV_FILE is not set"; exit 1; }
+          [ -n "${{ secrets.GUI_ENV_FILE }}" ]        || { echo "ERROR: GUI_ENV_FILE is not set"; exit 1; }
           [ -n "${{ secrets.PM2_APP_NAME }}" ]        || { echo "ERROR: PM2_APP_NAME is not set"; exit 1; }
-          [ -n "${{ secrets.EXPO_PUBLIC_API_URL }}" ] || { echo "ERROR: EXPO_PUBLIC_API_URL is not set"; exit 1; }
           echo "All required secrets are set"
 
       - name: Install zip and sshpass
@@ -48,15 +48,23 @@ jobs:
         run: npm run build --workspace=server
 
 
-      - name: Build app (Expo Web)
-        # expo export -p web inlines EXPO_PUBLIC_* vars into the static JS
-        # bundle at this exact step - there is no mathematador-app/.env in
-        # this checkout (it's gitignored) and no later step can retroactively
-        # fix a value baked in wrong here, so these must come from secrets,
-        # not a copied .env file (see issue #51).
+      - name: Fetch GUI env file from server
+        # expo export -p web (the next step) inlines EXPO_PUBLIC_* vars into
+        # the static JS bundle at build time, and there is no
+        # mathematador-app/.env in this checkout (it's gitignored, never
+        # committed) - so the real mathematador.gui.env has to be pulled
+        # down and in place *before* building, not copied to the server
+        # afterwards like it was before (see issue #51). The env file stays
+        # the single source of truth on the server; this just fetches it at
+        # the point in the pipeline where it's actually needed.
         env:
-          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
-          EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID }}
+          SSHPASS: ${{ secrets.SERVER_PASSWORD }}
+        run: |
+          sshpass -e scp -o StrictHostKeyChecking=no \
+            ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:"${{ secrets.GUI_ENV_FILE }}" \
+            mathematador-app/.env
+
+      - name: Build app (Expo Web)
         run: npm run build --workspace=mathematador-app
 
       - name: Prepare stage folder


### PR DESCRIPTION
Closes #51.

## Summary
Confirmed live, not theoretical: I fetched the actual deployed bundle at `mathematador.net` and it contains the literal string:

```
const o=String("http://localhost:4076")
```

That's `EXPO_PUBLIC_API_URL || "http://localhost:4076"` with the left side dead-code-eliminated to `undefined` at build time — meaning every API call from a real visitor's browser is trying to reach their own machine on port 4076, not the real backend.

## Root cause
`deploy.yml`'s job order:
1. `npm ci` → checkout has no `mathematador-app/.env` (gitignored, never committed)
2. **Build app (Expo Web)** — `expo export -p web` inlines `EXPO_PUBLIC_*` vars into the static JS bundle *at this exact point*
3. ...zip/transfer/unzip the already-built output onto the server...
4. **Copy environment files on server** — copies `GUI_ENV_FILE` to `web/.env`, *after* the build already ran without it
5. Restart PM2, which runs `npx serve -s web -l 4075` — a static file server that never reads a `.env` file at all

## Fix
**Revised from my first pass on this PR per feedback**: the env file is the server's actual configuration and should stay the single source of truth, not get duplicated into new GitHub Actions secrets holding the same values.

Since the pipeline already has SSH access to the server (reused later for `server/.env` and the PM2 restarts), it now **fetches `mathematador.gui.env` down into `mathematador-app/.env` before the build step** instead of copying it to the server after. Same file, same existing `GUI_ENV_FILE` secret (just restored to the "Validate server secrets" check) — no new secrets at all. `serve` (the static file server PM2 runs for the GUI) still never reads a `.env` at runtime, so the post-build copy to `web/.env` stays removed as genuinely dead weight.

## What you need to do
- Make sure `mathematador.gui.env` (the file `GUI_ENV_FILE` points at) actually contains `EXPO_PUBLIC_API_URL` set to the real, browser-reachable backend URL — not `localhost`.
- Once #66 ("Sign in with Google") is ready to go live, add `EXPO_PUBLIC_GOOGLE_CLIENT_ID="212955714606-sq33s6ddf1p10q1tlab40u232ocmpjfo.apps.googleusercontent.com"` to that same file — it'll get picked up automatically by this same fetch step.

## Test plan
- [x] YAML validated (`js-yaml` parse)
- [x] `npm run lint` passes
- [ ] **Needs a real deploy to fully verify** — I can't run this workflow myself (it requires the repo's deploy secrets/server access, and `mathematador.gui.env`'s actual current content). Once deployed, worth checking the bundle again the same way I did here (fetch the built JS and confirm it no longer contains `localhost:4076`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)